### PR TITLE
fix: Single-file inspect mode, MPS writer and Diff engine extracted into the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ lp_parser convert problem.lp --format mps -o problem.mps     # LP -> MPS
 lp_parser convert problem.mps --format mps -o rewritten.mps  # MPS -> MPS
 ```
 
+> **Caveat (LP → MPS):** a variable that appears only in constraints and is
+> never given an explicit bound defaults to `Free` internally, which is
+> written out as an MPS `FR` bound. LP format's own default for such a
+> variable is `[0, +inf)`, not free -- so an unbounded-looking variable can
+> widen to include negative values once converted to MPS. Declare bounds
+> explicitly (even a redundant `x >= 0`) in the LP source if this distinction
+> matters to the downstream solver.
+
 ### `solve` — run an external solver (requires `lp-solvers` feature)
 
 | Option                | Default | Description                      |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supported specifications: [IBM CPLEX v22.1.1](https://www.ibm.com/docs/en/icos/2
 - **Problem modification** — rename / update / remove objectives, constraints, variables, coefficients, and RHS values
 - **Variable types** — integer, general, bounded, free, semi-continuous
 - **Analysis** — statistics, matrix density, sparsity, coefficient ranges, issue detection with configurable thresholds
-- **Diff** (`diff` feature) — structural comparison between two LP files
+- **Diff** (`diff` feature) — structural and numeric comparison between two LP problems, callable from the library via [`LpProblem::diff`](https://docs.rs/lp_parser_rs) or `diff::compare`
 - **Serialisation** (`serde` feature) — JSON / YAML support
 - **External solvers** (`lp-solvers` feature) — CBC, Gurobi, CPLEX, GLPK via the [lp-solvers](https://crates.io/crates/lp-solvers) crate
 

--- a/README.md
+++ b/README.md
@@ -198,16 +198,18 @@ lp_parser solve problem.lp --format json --pretty
 
 The selected solver binary must be installed on your `PATH`. The compatibility layer does **not** support multiple objectives (errors), strict inequalities (`<`, `>`), or SOS constraints (ignored with a warning).
 
-## Interactive TUI Diff Viewer (`lp_diff`)
+## LP Model Explorer and Diff Viewer (`lp_diff`)
 
-A terminal UI for comparing LP/MPS files with coefficient-level side-by-side diffs, fuzzy search, filtering, and integrated [HiGHS](https://highs.dev) solving. Built with [ratatui](https://ratatui.rs).
+A terminal UI for exploring a single LP/MPS model or comparing two, with coefficient-level side-by-side diffs, fuzzy search, filtering, and integrated [HiGHS](https://highs.dev) solving. Built with [ratatui](https://ratatui.rs). Pass one file to inspect a model, or two files to diff them.
 
 ![lp_diff demo](https://raw.githubusercontent.com/dandxy89/lp_parser_rs/main/tui/assets/demo.gif)
 
 ```bash
 cargo install --path tui
-lp_diff base.lp modified.lp            # interactive
-lp_diff base.lp modified.lp --summary  # non-interactive summary
+lp_diff model.lp                       # inspect a single model
+lp_diff base.lp modified.lp            # diff two files
+lp_diff model.lp --summary             # non-interactive single-model summary
+lp_diff base.lp modified.lp --summary  # non-interactive diff summary
 ```
 
 #### Tolerance & rename (parity with `lp_parser diff`)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Supported specifications: [IBM CPLEX v22.1.1](https://www.ibm.com/docs/en/icos/2
 
 ## Features
 
-- **Parsing & writing** — round-trip LP files (parse → modify → write → parse) with configurable formatting
+- **Parsing & writing** — round-trip LP files (parse → modify → write → parse) with configurable formatting; MPS files can also be written via [`mps::writer`](https://docs.rs/lp_parser_rs) (`write_mps_string`), letting LP and MPS problems convert to either format
 - **Problem modification** — rename / update / remove objectives, constraints, variables, coefficients, and RHS values
 - **Variable types** — integer, general, bounded, free, semi-continuous
 - **Analysis** — statistics, matrix density, sparsity, coefficient ranges, issue detection with configurable thresholds
@@ -163,12 +163,12 @@ lp_parser diff old.lp new.lp --rename '\[\d+\]$' '[N]' --format json --pretty
 
 | Option                  | Default | Description                                 |
 | ----------------------- | ------- | ------------------------------------------- |
-| `<FILE>`                | —       | Path to the LP file                         |
+| `<FILE>`                | —       | Path to the LP or MPS file (`.mps` extension reads MPS) |
 | `-o, --output <PATH>`   | stdout  | Output file or directory (required for CSV) |
-| `-f, --format <FMT>`    | `lp`    | `lp`, `csv`, `json`, `yaml`                 |
+| `-f, --format <FMT>`    | `lp`    | `lp`, `mps`, `csv`, `json`, `yaml`          |
 | `--pretty`              | off     | Pretty-print JSON/YAML                      |
 | `--precision <N>`       | `6`     | Decimal precision for numbers               |
-| `--max-line-length <N>` | `80`    | Line-wrap threshold for LP output           |
+| `--max-line-length <N>` | `80`    | Line-wrap threshold for LP output            |
 | `--no-problem-name`     | off     | Omit problem-name comment in LP output      |
 | `--compact`             | off     | No section spacing                          |
 
@@ -176,6 +176,8 @@ lp_parser diff old.lp new.lp --rename '\[\d+\]$' '[N]' --format json --pretty
 lp_parser convert problem.lp --format lp --precision 4 --compact
 lp_parser convert problem.lp --format csv --output ./out     # writes constraints.csv, objectives.csv, variables.csv
 lp_parser convert problem.lp --format json --pretty -o problem.json
+lp_parser convert problem.lp --format mps -o problem.mps     # LP -> MPS
+lp_parser convert problem.mps --format mps -o rewritten.mps  # MPS -> MPS
 ```
 
 ### `solve` — run an external solver (requires `lp-solvers` feature)

--- a/rust/resources/mps/pl_mi_only_bounds.mps
+++ b/rust/resources/mps/pl_mi_only_bounds.mps
@@ -1,0 +1,15 @@
+NAME        pl_mi_only_bounds
+ROWS
+ N  obj
+ L  c1
+COLUMNS
+    x1        obj       1
+    x1        c1        1
+    x2        obj       1
+    x2        c1        1
+RHS
+    RHS       c1        10
+BOUNDS
+ PL BOUND     x1
+ MI BOUND     x2
+ENDATA

--- a/rust/src/analysis.rs
+++ b/rust/src/analysis.rs
@@ -563,7 +563,7 @@ impl LpProblem {
         let variables = self.analyze_variables();
         let constraints = self.analyze_constraints();
         let coefficients = self.analyze_coefficients(config);
-        let issues = self.detect_issues(&summary, &variables, &constraints, &coefficients, config);
+        let issues = Self::detect_issues(&summary, &variables, &constraints, &coefficients, config);
 
         ProblemAnalysis { summary, sparsity, variables, constraints, coefficients, issues }
     }
@@ -829,9 +829,7 @@ impl LpProblem {
     }
 
     /// Detect issues and generate warnings.
-    #[allow(clippy::unused_self)]
     fn detect_issues(
-        &self,
         summary: &ProblemSummary,
         variables: &VariableAnalysis,
         constraints: &ConstraintAnalysis,

--- a/rust/src/bin/lp_parser/cli.rs
+++ b/rust/src/bin/lp_parser/cli.rs
@@ -181,6 +181,8 @@ pub enum ConvertFormat {
     /// LP file format
     #[default]
     Lp,
+    /// MPS file format
+    Mps,
     /// CSV files (constraints.csv, objectives.csv, variables.csv)
     #[cfg(feature = "csv")]
     Csv,

--- a/rust/src/bin/lp_parser/main.rs
+++ b/rust/src/bin/lp_parser/main.rs
@@ -3,7 +3,7 @@
 mod cli;
 
 #[cfg(feature = "diff")]
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::borrow::Cow;
 use std::fs;
 use std::io::{self, Stdout, Write};
 use std::path::PathBuf;
@@ -16,9 +16,7 @@ use cli::{AnalyzeArgs, Cli, Commands, ConvertArgs, ConvertFormat, InfoArgs, Outp
 use cli::{SolveArgs, Solver};
 use lp_parser_rs::analysis::AnalysisConfig;
 #[cfg(feature = "diff")]
-use lp_parser_rs::interner::NameId;
-#[cfg(feature = "diff")]
-use lp_parser_rs::model::Coefficient;
+use lp_parser_rs::diff::{DiffOptions, DiffTol, LpDiff};
 use lp_parser_rs::model::{Constraint, VariableType};
 use lp_parser_rs::parser::parse_file;
 use lp_parser_rs::problem::LpProblem;
@@ -281,42 +279,22 @@ fn build_info_value(problem: &LpProblem, args: &InfoArgs) -> serde_json::Value {
     info
 }
 
-/// Absolute and relative tolerances for treating two floats as different.
+/// Coerce a closure into the higher-ranked `Fn(&str) -> Cow<str>` shape expected
+/// by [`lp_parser_rs::diff::Normaliser`]. The helper's explicit `for<'a>` bound
+/// steers closure lifetime inference, which does not converge on its own.
 #[cfg(feature = "diff")]
-#[derive(Clone, Copy)]
-struct DiffTol {
-    abs: f64,
-    rel: f64,
-}
-
-#[cfg(feature = "diff")]
-impl DiffTol {
-    /// Return true if `a` and `b` differ beyond both tolerances.
-    fn differ(self, a: f64, b: f64) -> bool {
-        let diff = (a - b).abs();
-        if diff == 0.0 {
-            return false;
-        }
-        let scale = a.abs().max(b.abs());
-        diff > self.abs && diff > self.rel * scale
-    }
-}
-
-/// The computed differences between two LP problems, keyed by canonical name.
-#[cfg(feature = "diff")]
-struct LpDiff {
-    vars_added: Vec<String>,
-    vars_removed: Vec<String>,
-    vars_type_changed: Vec<(String, String, String)>,
-    cons_added: Vec<String>,
-    cons_removed: Vec<String>,
-    cons_modified: Vec<(String, Vec<String>)>,
-    objs_added: Vec<String>,
-    objs_removed: Vec<String>,
-    objs_modified: Vec<(String, Vec<String>)>,
+fn as_normaliser<F>(f: F) -> F
+where
+    F: for<'a> Fn(&'a str) -> Cow<'a, str>,
+{
+    f
 }
 
 /// Apply each rename rule in turn, returning the canonical form of `name`.
+///
+/// This is the CLI's regex-based `--rename` normaliser; it is wrapped in a
+/// closure and handed to the library diff engine as a [`lp_parser_rs::diff::Normaliser`],
+/// keeping the `regex` dependency out of the core crate.
 #[cfg(feature = "diff")]
 fn apply_rename_rules(name: &str, rules: &[(regex::Regex, String)]) -> String {
     let mut s = name.to_string();
@@ -324,148 +302,6 @@ fn apply_rename_rules(name: &str, rules: &[(regex::Regex, String)]) -> String {
         s = re.replace_all(&s, rep.as_str()).into_owned();
     }
     s
-}
-
-/// Build a coefficient map keyed by canonical variable name.
-#[cfg(feature = "diff")]
-fn coeff_map(problem: &LpProblem, coeffs: &[Coefficient], rules: &[(regex::Regex, String)]) -> BTreeMap<String, f64> {
-    coeffs.iter().map(|c| (apply_rename_rules(problem.resolve(c.name), rules), c.value)).collect()
-}
-
-/// Count coefficients that changed value, were removed, or were added.
-#[cfg(feature = "diff")]
-fn count_coeff_diffs(m1: &BTreeMap<String, f64>, m2: &BTreeMap<String, f64>, tol: DiffTol) -> usize {
-    let mut diffs = 0usize;
-    for (k, v1) in m1 {
-        match m2.get(k) {
-            Some(v2) if tol.differ(*v1, *v2) => diffs += 1,
-            None => diffs += 1,
-            _ => {}
-        }
-    }
-    diffs += m2.keys().filter(|k| !m1.contains_key(*k)).count();
-    diffs
-}
-
-/// Describe how each common constraint changed (operator, rhs, coefficients).
-#[cfg(feature = "diff")]
-fn diff_modified_constraints(
-    p1: &LpProblem,
-    p2: &LpProblem,
-    ccons1: &HashMap<String, NameId>,
-    ccons2: &HashMap<String, NameId>,
-    common: &[String],
-    rules: &[(regex::Regex, String)],
-    tol: DiffTol,
-) -> Vec<(String, Vec<String>)> {
-    let mut modified = Vec::new();
-    for name in common {
-        let c1 = &p1.constraints[&ccons1[name]];
-        let c2 = &p2.constraints[&ccons2[name]];
-        let mut changes = Vec::new();
-        match (c1, c2) {
-            (
-                Constraint::Standard { coefficients: cf1, operator: op1, rhs: r1, .. },
-                Constraint::Standard { coefficients: cf2, operator: op2, rhs: r2, .. },
-            ) => {
-                if op1 != op2 {
-                    changes.push(format!("operator {op1} -> {op2}"));
-                }
-                if tol.differ(*r1, *r2) {
-                    changes.push(format!("rhs {r1} -> {r2}"));
-                }
-                let coef_diffs = count_coeff_diffs(&coeff_map(p1, cf1, rules), &coeff_map(p2, cf2, rules), tol);
-                if coef_diffs > 0 {
-                    changes.push(format!("{coef_diffs} coefficient change(s)"));
-                }
-            }
-            (Constraint::SOS { .. }, Constraint::SOS { .. }) => {
-                if c1 != c2 {
-                    changes.push("SOS definition changed".to_string());
-                }
-            }
-            _ => changes.push("constraint kind changed (Standard <-> SOS)".to_string()),
-        }
-        if !changes.is_empty() {
-            modified.push((name.clone(), changes));
-        }
-    }
-    modified
-}
-
-/// Describe how each common objective's coefficients changed.
-#[cfg(feature = "diff")]
-fn diff_modified_objectives(
-    p1: &LpProblem,
-    p2: &LpProblem,
-    cobjs1: &HashMap<String, NameId>,
-    cobjs2: &HashMap<String, NameId>,
-    common: &[String],
-    rules: &[(regex::Regex, String)],
-    tol: DiffTol,
-) -> Vec<(String, Vec<String>)> {
-    let mut modified = Vec::new();
-    for name in common {
-        let o1 = &p1.objectives[&cobjs1[name]];
-        let o2 = &p2.objectives[&cobjs2[name]];
-        let coef_diffs = count_coeff_diffs(&coeff_map(p1, &o1.coefficients, rules), &coeff_map(p2, &o2.coefficients, rules), tol);
-        if coef_diffs > 0 {
-            modified.push((name.clone(), vec![format!("{coef_diffs} coefficient change(s)")]));
-        }
-    }
-    modified
-}
-
-/// Compare two parsed problems, returning the structural and numeric diff.
-#[cfg(feature = "diff")]
-// The paired 1/2-suffixed bindings are the domain language of a two-file diff.
-#[allow(clippy::similar_names)]
-fn compute_lp_diff(p1: &LpProblem, p2: &LpProblem, rules: &[(regex::Regex, String)], tol: DiffTol) -> LpDiff {
-    let canon = |problem: &LpProblem, ids: Vec<NameId>| -> HashMap<String, NameId> {
-        ids.iter().map(|id| (apply_rename_rules(problem.resolve(*id), rules), *id)).collect()
-    };
-
-    let cvars1 = canon(p1, p1.variables.keys().copied().collect());
-    let cvars2 = canon(p2, p2.variables.keys().copied().collect());
-    let ccons1: HashMap<String, NameId> =
-        p1.constraints.values().map(|c| (apply_rename_rules(p1.resolve(c.name()), rules), c.name())).collect();
-    let ccons2: HashMap<String, NameId> =
-        p2.constraints.values().map(|c| (apply_rename_rules(p2.resolve(c.name()), rules), c.name())).collect();
-    let cobjs1 = canon(p1, p1.objectives.keys().copied().collect());
-    let cobjs2 = canon(p2, p2.objectives.keys().copied().collect());
-
-    let set_of = |m: &HashMap<String, NameId>| -> BTreeSet<String> { m.keys().cloned().collect() };
-    let vars1 = set_of(&cvars1);
-    let vars2 = set_of(&cvars2);
-    let cons1 = set_of(&ccons1);
-    let cons2 = set_of(&ccons2);
-    let objs1 = set_of(&cobjs1);
-    let objs2 = set_of(&cobjs2);
-
-    // Sorted intersections keep modified-section output deterministic.
-    let cons_common: Vec<String> = cons1.intersection(&cons2).cloned().collect();
-    let objs_common: Vec<String> = objs1.intersection(&objs2).cloned().collect();
-
-    let mut vars_type_changed = Vec::new();
-    for name in vars1.intersection(&vars2) {
-        let t1 = &p1.variables[&cvars1[name]].var_type;
-        let t2 = &p2.variables[&cvars2[name]].var_type;
-        if t1 != t2 {
-            vars_type_changed.push((name.clone(), format!("{t1:?}"), format!("{t2:?}")));
-        }
-    }
-
-    LpDiff {
-        vars_added: vars2.difference(&vars1).cloned().collect(),
-        vars_removed: vars1.difference(&vars2).cloned().collect(),
-        vars_type_changed,
-        cons_added: cons2.difference(&cons1).cloned().collect(),
-        cons_removed: cons1.difference(&cons2).cloned().collect(),
-        cons_modified: diff_modified_constraints(p1, p2, &ccons1, &ccons2, &cons_common, rules, tol),
-        objs_added: objs2.difference(&objs1).cloned().collect(),
-        objs_removed: objs1.difference(&objs2).cloned().collect(),
-        objs_modified: diff_modified_objectives(p1, p2, &cobjs1, &cobjs2, &objs_common, rules, tol),
-    }
 }
 
 /// Render the diff in human-readable text form.
@@ -583,7 +419,11 @@ fn cmd_diff(args: &DiffArgs, verbose: bool, quiet: bool) -> Result<(), BoxError>
     let p1 = LpProblem::parse(&content1)?;
     let p2 = LpProblem::parse(&content2)?;
 
-    let diff = compute_lp_diff(&p1, &p2, &rules, tol);
+    // Hand the CLI's regex rename rules to the library engine as a normaliser
+    // closure, keeping `regex` out of the core crate.
+    let normalise = as_normaliser(|name: &str| Cow::Owned(apply_rename_rules(name, &rules)));
+    let options = DiffOptions { tol, normalise: &normalise };
+    let diff = p1.diff(&p2, &options);
 
     let mut writer = OutputWriter::new(args.output.clone())?;
     match args.format {

--- a/rust/src/bin/lp_parser/main.rs
+++ b/rust/src/bin/lp_parser/main.rs
@@ -283,7 +283,7 @@ fn build_info_value(problem: &LpProblem, args: &InfoArgs) -> serde_json::Value {
 /// by [`lp_parser_rs::diff::Normaliser`]. The helper's explicit `for<'a>` bound
 /// steers closure lifetime inference, which does not converge on its own.
 #[cfg(feature = "diff")]
-fn as_normaliser<F>(f: F) -> F
+const fn as_normaliser<F>(f: F) -> F
 where
     F: for<'a> Fn(&'a str) -> Cow<'a, str>,
 {

--- a/rust/src/bin/lp_parser/main.rs
+++ b/rust/src/bin/lp_parser/main.rs
@@ -449,11 +449,20 @@ fn cmd_diff(args: &DiffArgs, verbose: bool, quiet: bool) -> Result<(), BoxError>
     Ok(())
 }
 
+/// Parse `content` as MPS if `path` has a `.mps` extension (case-insensitive),
+/// otherwise as LP. Scoped to `convert` so that `MPS -> MPS` round trips work;
+/// other subcommands are unaffected and remain LP-only.
+fn parse_convert_input(path: &std::path::Path, content: &str) -> Result<LpProblem, BoxError> {
+    let is_mps = path.extension().and_then(|ext| ext.to_str()).is_some_and(|ext| ext.eq_ignore_ascii_case("mps"));
+    if is_mps { Ok(LpProblem::parse_mps(content)?) } else { Ok(LpProblem::parse(content)?) }
+}
+
 fn cmd_convert(args: ConvertArgs, verbose: bool, quiet: bool) -> Result<(), BoxError> {
+    use lp_parser_rs::mps::writer::{MpsWriterOptions, write_mps_string_with_options};
     use lp_parser_rs::writer::{LpWriterOptions, write_lp_string_with_options};
 
     let content = parse_file(&args.file)?;
-    let problem = LpProblem::parse(&content)?;
+    let problem = parse_convert_input(&args.file, &content)?;
 
     if !quiet && verbose {
         eprintln!("Converting file: {}", args.file.display());
@@ -468,6 +477,13 @@ fn cmd_convert(args: ConvertArgs, verbose: bool, quiet: bool) -> Result<(), BoxE
                 include_section_spacing: !args.compact,
             };
             let output = write_lp_string_with_options(&problem, &options);
+
+            let mut writer = OutputWriter::new(args.output)?;
+            write!(writer, "{output}")?;
+        }
+        ConvertFormat::Mps => {
+            let options = MpsWriterOptions { decimal_precision: args.precision, ..MpsWriterOptions::default() };
+            let output = write_mps_string_with_options(&problem, &options)?;
 
             let mut writer = OutputWriter::new(args.output)?;
             write!(writer, "{output}")?;

--- a/rust/src/diff.rs
+++ b/rust/src/diff.rs
@@ -419,6 +419,18 @@ mod tests {
         let diff = p1.diff(&p2, &opts(DiffTol::default()));
         assert_eq!(diff.objs_modified.len(), 1);
         assert_eq!(diff.objs_modified[0].0, "obj");
+
+        // Second objective `obj2` present in one problem, absent from the other.
+        let single = parse("Minimize\n obj: 2 x + 3 y\nSubject To\n c1: x + y >= 1\nEnd");
+        let double = parse("Minimize\n obj: 2 x + 3 y\n obj2: x\nSubject To\n c1: x + y >= 1\nEnd");
+
+        let diff = single.diff(&double, &opts(DiffTol::default()));
+        assert_eq!(diff.objs_added, vec!["obj2".to_string()]);
+        assert!(diff.objs_removed.is_empty());
+
+        let diff = double.diff(&single, &opts(DiffTol::default()));
+        assert_eq!(diff.objs_removed, vec!["obj2".to_string()]);
+        assert!(diff.objs_added.is_empty());
     }
 
     #[test]

--- a/rust/src/diff.rs
+++ b/rust/src/diff.rs
@@ -1,0 +1,457 @@
+//! Structural and numeric diff engine for two parsed [`LpProblem`]s.
+//!
+//! This module is gated behind the `diff` feature. It is the single, shared
+//! definition of "how two LP problems differ" used by both the `lp_parser diff`
+//! CLI subcommand and the `lp_diff` TUI: keeping the comparison logic here
+//! prevents the two front-ends from drifting apart.
+//!
+//! # Overview
+//!
+//! - [`DiffTol`] carries the absolute and relative tolerances that decide when
+//!   two floats count as different.
+//! - [`DiffOptions`] bundles a [`DiffTol`] with a caller-supplied name
+//!   normaliser so callers can rewrite variable/constraint/objective names
+//!   (e.g. the CLI's regex `--rename` rules) *without* forcing a `regex`
+//!   dependency onto this crate.
+//! - [`compare`] (or the convenience [`LpProblem::diff`] method) walks both
+//!   problems and returns an [`LpDiff`] describing every added, removed, or
+//!   modified variable, constraint, and objective.
+//!
+//! # Example
+//!
+//! ```rust
+//! use std::borrow::Cow;
+//! use lp_parser_rs::LpProblem;
+//! use lp_parser_rs::diff::{DiffOptions, DiffTol};
+//!
+//! let a = LpProblem::parse("Minimize\n obj: 2 x\nSubject To\n c1: x >= 1\nEnd")?;
+//! let b = LpProblem::parse("Minimize\n obj: 3 x\nSubject To\n c1: x >= 2\nEnd")?;
+//!
+//! // Identity normaliser: no renaming. Prefer a named `fn` over a closure —
+//! // closure lifetime inference does not converge on the higher-ranked
+//! // `Fn(&str) -> Cow<str>` signature the normaliser requires.
+//! fn identity(name: &str) -> Cow<'_, str> {
+//!     Cow::Borrowed(name)
+//! }
+//! let options = DiffOptions { tol: DiffTol::default(), normalise: &identity };
+//!
+//! let diff = a.diff(&b, &options);
+//! assert_eq!(diff.cons_modified.len(), 1); // c1's rhs changed
+//! assert_eq!(diff.objs_modified.len(), 1); // obj's coefficient changed
+//! # Ok::<(), lp_parser_rs::LpParseError>(())
+//! ```
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use crate::interner::NameId;
+use crate::model::{Coefficient, Constraint};
+use crate::problem::LpProblem;
+
+/// A name normaliser: rewrites a name before matching, returning the original
+/// borrowed unchanged when no rewrite applies (avoiding an allocation).
+///
+/// The CLI passes a closure wrapping its regex `--rename` rules; consumers that
+/// do not rename names can pass an identity closure such as
+/// `|name: &str| std::borrow::Cow::Borrowed(name)`.
+pub type Normaliser<'a> = &'a dyn Fn(&str) -> Cow<'_, str>;
+
+/// Absolute and relative tolerances for treating two floats as different.
+///
+/// Two values `a` and `b` differ when their absolute difference exceeds **both**
+/// the absolute tolerance and the relative tolerance scaled by
+/// `max(|a|, |b|)`. Equal values (or a zero difference) never differ.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DiffTol {
+    /// Absolute tolerance: differences no larger than this are ignored.
+    pub abs: f64,
+    /// Relative tolerance: differences no larger than `rel * max(|a|, |b|)` are ignored.
+    pub rel: f64,
+}
+
+impl Default for DiffTol {
+    /// Both tolerances zero: any non-zero difference counts as a change.
+    fn default() -> Self {
+        Self { abs: 0.0, rel: 0.0 }
+    }
+}
+
+impl DiffTol {
+    /// Construct a tolerance from an absolute and a relative component.
+    #[must_use]
+    pub fn new(abs: f64, rel: f64) -> Self {
+        debug_assert!(abs.is_finite() && abs >= 0.0, "abs tolerance must be finite and non-negative");
+        debug_assert!(rel.is_finite() && rel >= 0.0, "rel tolerance must be finite and non-negative");
+        Self { abs, rel }
+    }
+
+    /// Return true if `a` and `b` differ beyond both tolerances.
+    #[must_use]
+    pub fn differ(self, a: f64, b: f64) -> bool {
+        debug_assert!(self.abs.is_finite() && self.abs >= 0.0, "abs tolerance must be finite and non-negative");
+        debug_assert!(self.rel.is_finite() && self.rel >= 0.0, "rel tolerance must be finite and non-negative");
+        let diff = (a - b).abs();
+        if diff == 0.0 {
+            return false;
+        }
+        let scale = a.abs().max(b.abs());
+        diff > self.abs && diff > self.rel * scale
+    }
+}
+
+/// Comparison options shared by a whole diff: numeric tolerances plus a
+/// caller-supplied name normaliser applied to every name in both problems.
+///
+/// The normaliser lets callers rewrite names (e.g. to strip volatile row/column
+/// indices) before matching, without this crate depending on `regex`.
+pub struct DiffOptions<'a> {
+    /// Numeric tolerances for RHS and coefficient comparisons.
+    pub tol: DiffTol,
+    /// Name rewrite applied to every variable, constraint, and objective name.
+    pub normalise: Normaliser<'a>,
+}
+
+/// The computed differences between two LP problems, keyed by canonical
+/// (normalised) name.
+///
+/// Names in every field are already normalised through
+/// [`DiffOptions::normalise`]. The `*_modified` fields pair a name with a list
+/// of human-readable change descriptions.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct LpDiff {
+    /// Variables present only in the second problem.
+    pub vars_added: Vec<String>,
+    /// Variables present only in the first problem.
+    pub vars_removed: Vec<String>,
+    /// Variables whose type changed: `(name, old_type, new_type)`.
+    pub vars_type_changed: Vec<(String, String, String)>,
+    /// Constraints present only in the second problem.
+    pub cons_added: Vec<String>,
+    /// Constraints present only in the first problem.
+    pub cons_removed: Vec<String>,
+    /// Constraints present in both but changed: `(name, changes)`.
+    pub cons_modified: Vec<(String, Vec<String>)>,
+    /// Objectives present only in the second problem.
+    pub objs_added: Vec<String>,
+    /// Objectives present only in the first problem.
+    pub objs_removed: Vec<String>,
+    /// Objectives present in both but changed: `(name, changes)`.
+    pub objs_modified: Vec<(String, Vec<String>)>,
+}
+
+impl LpProblem {
+    /// Compare this problem against `other`, returning the structural and numeric diff.
+    ///
+    /// Convenience method equivalent to [`compare(self, other, options)`](compare).
+    #[must_use]
+    pub fn diff(&self, other: &LpProblem, options: &DiffOptions) -> LpDiff {
+        compare(self, other, options)
+    }
+}
+
+/// Build a coefficient map keyed by canonical (normalised) variable name.
+fn coeff_map(problem: &LpProblem, coeffs: &[Coefficient], normalise: Normaliser) -> BTreeMap<String, f64> {
+    coeffs.iter().map(|c| (normalise(problem.resolve(c.name)).into_owned(), c.value)).collect()
+}
+
+/// Count coefficients that changed value, were removed, or were added.
+fn count_coeff_diffs(m1: &BTreeMap<String, f64>, m2: &BTreeMap<String, f64>, tol: DiffTol) -> usize {
+    let mut diffs = 0usize;
+    for (k, v1) in m1 {
+        match m2.get(k) {
+            Some(v2) if tol.differ(*v1, *v2) => diffs += 1,
+            None => diffs += 1,
+            _ => {}
+        }
+    }
+    diffs += m2.keys().filter(|k| !m1.contains_key(*k)).count();
+    diffs
+}
+
+/// Describe how each common constraint changed (operator, rhs, coefficients).
+fn diff_modified_constraints(
+    p1: &LpProblem,
+    p2: &LpProblem,
+    ccons1: &HashMap<String, NameId>,
+    ccons2: &HashMap<String, NameId>,
+    common: &[String],
+    normalise: Normaliser,
+    tol: DiffTol,
+) -> Vec<(String, Vec<String>)> {
+    let mut modified = Vec::new();
+    for name in common {
+        let c1 = &p1.constraints[&ccons1[name]];
+        let c2 = &p2.constraints[&ccons2[name]];
+        let mut changes = Vec::new();
+        match (c1, c2) {
+            (
+                Constraint::Standard { coefficients: cf1, operator: op1, rhs: r1, .. },
+                Constraint::Standard { coefficients: cf2, operator: op2, rhs: r2, .. },
+            ) => {
+                if op1 != op2 {
+                    changes.push(format!("operator {op1} -> {op2}"));
+                }
+                if tol.differ(*r1, *r2) {
+                    changes.push(format!("rhs {r1} -> {r2}"));
+                }
+                let coef_diffs = count_coeff_diffs(&coeff_map(p1, cf1, normalise), &coeff_map(p2, cf2, normalise), tol);
+                if coef_diffs > 0 {
+                    changes.push(format!("{coef_diffs} coefficient change(s)"));
+                }
+            }
+            (Constraint::SOS { .. }, Constraint::SOS { .. }) => {
+                if c1 != c2 {
+                    changes.push("SOS definition changed".to_string());
+                }
+            }
+            _ => changes.push("constraint kind changed (Standard <-> SOS)".to_string()),
+        }
+        if !changes.is_empty() {
+            modified.push((name.clone(), changes));
+        }
+    }
+    modified
+}
+
+/// Describe how each common objective's coefficients changed.
+fn diff_modified_objectives(
+    p1: &LpProblem,
+    p2: &LpProblem,
+    cobjs1: &HashMap<String, NameId>,
+    cobjs2: &HashMap<String, NameId>,
+    common: &[String],
+    normalise: Normaliser,
+    tol: DiffTol,
+) -> Vec<(String, Vec<String>)> {
+    let mut modified = Vec::new();
+    for name in common {
+        let o1 = &p1.objectives[&cobjs1[name]];
+        let o2 = &p2.objectives[&cobjs2[name]];
+        let coef_diffs = count_coeff_diffs(&coeff_map(p1, &o1.coefficients, normalise), &coeff_map(p2, &o2.coefficients, normalise), tol);
+        if coef_diffs > 0 {
+            modified.push((name.clone(), vec![format!("{coef_diffs} coefficient change(s)")]));
+        }
+    }
+    modified
+}
+
+/// Compare two parsed problems, returning the structural and numeric diff.
+///
+/// Every name is normalised through `options.normalise` before matching, so
+/// renamed-but-equal entries collapse together. Numeric comparisons respect
+/// `options.tol`. The result's list fields are ordered deterministically
+/// (sorted by canonical name) so callers can render stable output.
+#[must_use]
+// The paired 1/2-suffixed bindings are the domain language of a two-file diff.
+#[allow(clippy::similar_names)]
+pub fn compare(p1: &LpProblem, p2: &LpProblem, options: &DiffOptions) -> LpDiff {
+    let normalise = options.normalise;
+    let tol = options.tol;
+
+    let canon = |problem: &LpProblem, ids: Vec<NameId>| -> HashMap<String, NameId> {
+        ids.iter().map(|id| (normalise(problem.resolve(*id)).into_owned(), *id)).collect()
+    };
+
+    let cvars1 = canon(p1, p1.variables.keys().copied().collect());
+    let cvars2 = canon(p2, p2.variables.keys().copied().collect());
+    let ccons1: HashMap<String, NameId> =
+        p1.constraints.values().map(|c| (normalise(p1.resolve(c.name())).into_owned(), c.name())).collect();
+    let ccons2: HashMap<String, NameId> =
+        p2.constraints.values().map(|c| (normalise(p2.resolve(c.name())).into_owned(), c.name())).collect();
+    let cobjs1 = canon(p1, p1.objectives.keys().copied().collect());
+    let cobjs2 = canon(p2, p2.objectives.keys().copied().collect());
+
+    let set_of = |m: &HashMap<String, NameId>| -> BTreeSet<String> { m.keys().cloned().collect() };
+    let vars1 = set_of(&cvars1);
+    let vars2 = set_of(&cvars2);
+    let cons1 = set_of(&ccons1);
+    let cons2 = set_of(&ccons2);
+    let objs1 = set_of(&cobjs1);
+    let objs2 = set_of(&cobjs2);
+
+    // Sorted intersections keep modified-section output deterministic.
+    let cons_common: Vec<String> = cons1.intersection(&cons2).cloned().collect();
+    let objs_common: Vec<String> = objs1.intersection(&objs2).cloned().collect();
+
+    let mut vars_type_changed = Vec::new();
+    for name in vars1.intersection(&vars2) {
+        let t1 = &p1.variables[&cvars1[name]].var_type;
+        let t2 = &p2.variables[&cvars2[name]].var_type;
+        if t1 != t2 {
+            vars_type_changed.push((name.clone(), format!("{t1:?}"), format!("{t2:?}")));
+        }
+    }
+
+    LpDiff {
+        vars_added: vars2.difference(&vars1).cloned().collect(),
+        vars_removed: vars1.difference(&vars2).cloned().collect(),
+        vars_type_changed,
+        cons_added: cons2.difference(&cons1).cloned().collect(),
+        cons_removed: cons1.difference(&cons2).cloned().collect(),
+        cons_modified: diff_modified_constraints(p1, p2, &ccons1, &ccons2, &cons_common, normalise, tol),
+        objs_added: objs2.difference(&objs1).cloned().collect(),
+        objs_removed: objs1.difference(&objs2).cloned().collect(),
+        objs_modified: diff_modified_objectives(p1, p2, &cobjs1, &cobjs2, &objs_common, normalise, tol),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Identity normaliser: no renaming.
+    fn identity(name: &str) -> Cow<'_, str> {
+        Cow::Borrowed(name)
+    }
+
+    /// Strip a trailing `_<digits>` suffix from a name (a volatile index).
+    fn strip_index_suffix(name: &str) -> Cow<'_, str> {
+        match name.rfind('_') {
+            Some(idx) if idx + 1 < name.len() && name[idx + 1..].chars().all(|ch| ch.is_ascii_digit()) => {
+                Cow::Owned(name[..idx].to_string())
+            }
+            _ => Cow::Borrowed(name),
+        }
+    }
+
+    fn opts(tol: DiffTol) -> DiffOptions<'static> {
+        DiffOptions { tol, normalise: &identity }
+    }
+
+    // --- DiffTol tolerance edges ---------------------------------------------
+
+    #[test]
+    fn tol_zero_reports_any_nonzero_difference() {
+        let tol = DiffTol::default();
+        assert!(!tol.differ(1.0, 1.0));
+        assert!(tol.differ(1.0, 1.0 + 1e-12));
+    }
+
+    #[test]
+    fn tol_equal_within_absolute() {
+        let tol = DiffTol::new(0.5, 0.0);
+        // Difference of 0.4 is within abs=0.5.
+        assert!(!tol.differ(1.0, 1.4));
+        // Difference of 0.6 exceeds abs=0.5.
+        assert!(tol.differ(1.0, 1.6));
+    }
+
+    #[test]
+    fn tol_relative_scales_with_magnitude() {
+        // 1% relative tolerance.
+        let tol = DiffTol::new(0.0, 0.01);
+        // 0.5% change is within tolerance.
+        assert!(!tol.differ(1000.0, 1005.0));
+        // 2% change exceeds tolerance.
+        assert!(tol.differ(1000.0, 1020.0));
+    }
+
+    #[test]
+    fn tol_requires_both_tolerances_exceeded() {
+        // Differs only if BEYOND both abs AND rel.
+        let tol = DiffTol::new(10.0, 0.5);
+        // diff 8: below abs(10) -> not different even though 8 > 0.5*10.
+        assert!(!tol.differ(10.0, 18.0));
+        // diff 12: above abs(10) but 12 < 0.5*24 -> not different.
+        assert!(!tol.differ(12.0, 24.0));
+    }
+
+    #[test]
+    fn tol_zero_baseline() {
+        let tol = DiffTol::new(0.0, 0.5);
+        // Relative scale is max(|0|, |1|) = 1; diff 1 > 0.5 -> different.
+        assert!(tol.differ(0.0, 1.0));
+        // Both zero -> no difference.
+        assert!(!tol.differ(0.0, 0.0));
+    }
+
+    // --- structural diff -----------------------------------------------------
+
+    fn parse(src: &str) -> LpProblem {
+        LpProblem::parse(src).expect("test LP must parse")
+    }
+
+    #[test]
+    fn detects_added_and_removed_variables() {
+        let p1 = parse("Minimize\n obj: 2 x + 3 y\nSubject To\n c1: x + y >= 1\nEnd");
+        let p2 = parse("Minimize\n obj: 2 x + 3 z\nSubject To\n c1: x + z >= 1\nEnd");
+        let diff = p1.diff(&p2, &opts(DiffTol::default()));
+        assert_eq!(diff.vars_added, vec!["z".to_string()]);
+        assert_eq!(diff.vars_removed, vec!["y".to_string()]);
+    }
+
+    #[test]
+    fn detects_variable_type_change() {
+        // `x` is continuous in p1, declared integer in p2.
+        let p1 = parse("Minimize\n obj: x\nSubject To\n c1: x >= 1\nEnd");
+        let p2 = parse("Minimize\n obj: x\nSubject To\n c1: x >= 1\nintegers\n x\nEnd");
+        let diff = p1.diff(&p2, &opts(DiffTol::default()));
+        assert_eq!(diff.vars_type_changed.len(), 1);
+        assert_eq!(diff.vars_type_changed[0].0, "x");
+    }
+
+    #[test]
+    fn detects_added_and_removed_constraints() {
+        let p1 = parse("Minimize\n obj: x + y\nSubject To\n c1: x + y >= 1\nEnd");
+        let p2 = parse("Minimize\n obj: x + y\nSubject To\n c2: x + y >= 1\nEnd");
+        let diff = p1.diff(&p2, &opts(DiffTol::default()));
+        assert_eq!(diff.cons_added, vec!["c2".to_string()]);
+        assert_eq!(diff.cons_removed, vec!["c1".to_string()]);
+    }
+
+    #[test]
+    fn detects_modified_constraint_operator_rhs_and_coefficients() {
+        let p1 = parse("Minimize\n obj: x + y\nSubject To\n c1: x + y >= 1\nEnd");
+        let p2 = parse("Minimize\n obj: x + y\nSubject To\n c1: 2 x + y <= 5\nEnd");
+        let diff = p1.diff(&p2, &opts(DiffTol::default()));
+        assert_eq!(diff.cons_modified.len(), 1);
+        let (name, changes) = &diff.cons_modified[0];
+        assert_eq!(name, "c1");
+        assert!(changes.iter().any(|c| c.contains("operator")));
+        assert!(changes.iter().any(|c| c.contains("rhs")));
+        assert!(changes.iter().any(|c| c.contains("coefficient change")));
+    }
+
+    #[test]
+    fn detects_added_removed_and_modified_objectives() {
+        let p1 = parse("Minimize\n obj: 2 x + 3 y\nSubject To\n c1: x + y >= 1\nEnd");
+        let p2 = parse("Minimize\n obj: 5 x + 3 y\nSubject To\n c1: x + y >= 1\nEnd");
+        let diff = p1.diff(&p2, &opts(DiffTol::default()));
+        assert_eq!(diff.objs_modified.len(), 1);
+        assert_eq!(diff.objs_modified[0].0, "obj");
+    }
+
+    #[test]
+    fn rhs_change_within_tolerance_is_ignored() {
+        let p1 = parse("Minimize\n obj: x\nSubject To\n c1: x >= 100\nEnd");
+        let p2 = parse("Minimize\n obj: x\nSubject To\n c1: x >= 100.4\nEnd");
+        // abs tolerance 0.5 suppresses the 0.4 rhs change.
+        let diff = p1.diff(&p2, &opts(DiffTol::new(0.5, 0.0)));
+        assert!(diff.cons_modified.is_empty());
+        // Without tolerance the change is reported.
+        let diff = p1.diff(&p2, &opts(DiffTol::default()));
+        assert_eq!(diff.cons_modified.len(), 1);
+    }
+
+    #[test]
+    fn normaliser_applied_on_both_sides() {
+        // Names carry a volatile numeric suffix on each side.
+        let p1 = parse("Minimize\n obj: x_1\nSubject To\n c_1: x_1 >= 1\nEnd");
+        let p2 = parse("Minimize\n obj: x_2\nSubject To\n c_2: x_2 >= 1\nEnd");
+
+        // Without normalisation, everything looks added/removed.
+        let diff = p1.diff(&p2, &opts(DiffTol::default()));
+        assert_eq!(diff.vars_added, vec!["x_2".to_string()]);
+        assert_eq!(diff.vars_removed, vec!["x_1".to_string()]);
+
+        // Strip the trailing `_<digits>` on both sides: names now match.
+        let options = DiffOptions { tol: DiffTol::default(), normalise: &strip_index_suffix };
+        let diff = p1.diff(&p2, &options);
+        assert!(diff.vars_added.is_empty());
+        assert!(diff.vars_removed.is_empty());
+        assert!(diff.cons_added.is_empty());
+        assert!(diff.cons_removed.is_empty());
+        // Constraint c is unchanged after normalisation.
+        assert!(diff.cons_modified.is_empty());
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,6 +12,7 @@
 //! - Owned, interned problem model (no lifetimes) built from a zero-copy grammar
 //! - Support for multiple LP file format specifications
 //! - Comprehensive parsing of all standard LP file components
+//! - Writers for both LP ([`writer`]) and MPS ([`mps::writer`]) output
 //! - Optional serialisation (`serde`) and a structural/numeric diff engine
 //!   ([`diff`], behind the `diff` feature)
 //!

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,7 +12,8 @@
 //! - Owned, interned problem model (no lifetimes) built from a zero-copy grammar
 //! - Support for multiple LP file format specifications
 //! - Comprehensive parsing of all standard LP file components
-//! - Optional serialisation and diff tracking
+//! - Optional serialisation (`serde`) and a structural/numeric diff engine
+//!   ([`diff`], behind the `diff` feature)
 //!
 //! # Quick Start
 //!
@@ -43,6 +44,9 @@ pub mod analysis;
 pub mod compat;
 #[cfg(feature = "csv")]
 pub mod csv;
+/// Structural and numeric diff engine for two [`LpProblem`]s (behind the `diff` feature).
+#[cfg(feature = "diff")]
+pub mod diff;
 /// Error types returned by the parsers ([`LpParseError`], [`LpResult`]).
 pub mod error;
 pub mod interner;
@@ -57,6 +61,8 @@ pub mod writer;
 
 // Crate-root re-exports of the primary public API, so downstream users do not
 // need deep module paths for the most common types and entry points.
+#[cfg(feature = "diff")]
+pub use diff::{DiffOptions, DiffTol, LpDiff, Normaliser, compare as compare_diff};
 pub use error::{LpParseError, LpResult};
 pub use interner::{NameId, NameInterner};
 // LALRPOP generated grammar module

--- a/rust/src/mps/mod.rs
+++ b/rust/src/mps/mod.rs
@@ -10,6 +10,10 @@ mod sections;
 mod state;
 #[cfg(test)]
 mod tests;
+/// MPS file writing ([`write_mps_string`](writer::write_mps_string) /
+/// [`write_mps_string_with_options`](writer::write_mps_string_with_options)),
+/// mirroring [`crate::writer`] for the LP format.
+pub mod writer;
 
 pub use state::{extract_mps_name, parse_mps};
 

--- a/rust/src/mps/snapshots/lp_parser_rs__mps__writer__tests__snapshot_representative_problem.snap
+++ b/rust/src/mps/snapshots/lp_parser_rs__mps__writer__tests__snapshot_representative_problem.snap
@@ -1,0 +1,33 @@
+---
+source: rust/src/mps/writer.rs
+expression: output
+---
+NAME          Sample
+OBJSENSE
+    MAX
+ROWS
+ N  profit
+ L  capacity
+COLUMNS
+    MARKER                 'MARKER'                 'INTORG'
+    x1         profit     3
+    x1         capacity   1
+    MARKER                 'MARKER'                 'INTEND'
+    x2         profit     2
+    x2         capacity   1
+    MARKER                 'MARKER'                 'INTORG'
+    x3         profit     1
+    x3         capacity   1
+    MARKER                 'MARKER'                 'INTEND'
+RHS
+    RHS        capacity   100
+BOUNDS
+ LO BOUND     x1         0
+ LO BOUND     x2         0
+ UP BOUND     x2         50
+ BV BOUND     x3
+SOS
+ S1 sos1
+    x1         1
+    x2         2
+ENDATA

--- a/rust/src/mps/writer.rs
+++ b/rust/src/mps/writer.rs
@@ -159,7 +159,7 @@ fn build_mps(output: &mut String, problem: &LpProblem, options: &MpsWriterOption
     write_columns_section(output, problem, &columns, options).expect("fmt::Write to String is infallible");
 
     write_rhs_section(output, problem, obj_row_name, options).expect("fmt::Write to String is infallible");
-    write_bounds_section(output, problem, options).expect("fmt::Write to String is infallible");
+    write_bounds_section(output, problem, options)?;
     write_sos_section(output, problem, options).expect("fmt::Write to String is infallible");
 
     writeln!(output, "ENDATA").expect("fmt::Write to String is infallible");
@@ -355,25 +355,78 @@ fn write_bound_flag(output: &mut String, bound_type: &str, var_name: &str) -> st
     writeln!(output, " {bound_type} {BOUNDS_VECTOR_LABEL:<9} {var_name}")
 }
 
+/// Build the validation error returned for a bound value that MPS cannot
+/// represent (`NaN`, or an infinite value on the "wrong" side of a bound
+/// that MPS has no flag for).
+fn invalid_bound_error(var_name: &str, message: &str) -> LpParseError {
+    LpParseError::validation_error(format!("variable '{var_name}' {message}"))
+}
+
 /// Write the bound line(s) for a single variable's [`VariableType`].
 ///
 /// See the module documentation for the `Integer`/`General`/`SemiContinuous`
-/// mapping caveats.
-fn write_variable_bound(output: &mut String, var_name: &str, var_type: &VariableType, precision: usize) -> std::fmt::Result {
+/// mapping caveats, and for the `Free`-default conversion caveat.
+///
+/// # Errors
+///
+/// Returns an error if a bound value is `NaN`, or is an infinite value MPS
+/// has no flag for (e.g. `UpperBound(-inf)`, `LowerBound(+inf)`) -- see
+/// [`write_upper_bound`], [`write_lower_bound`] and [`write_double_bound`].
+fn write_variable_bound(output: &mut String, var_name: &str, var_type: &VariableType, precision: usize) -> LpResult<()> {
     match *var_type {
-        VariableType::Free => write_bound_flag(output, "FR", var_name),
-        VariableType::LowerBound(lb) => write_bound_value(output, "LO", var_name, lb, precision),
+        VariableType::Free => {
+            write_bound_flag(output, "FR", var_name).expect("fmt::Write to String is infallible");
+            Ok(())
+        }
+        VariableType::LowerBound(lb) => write_lower_bound(output, var_name, lb, precision),
         VariableType::UpperBound(ub) => write_upper_bound(output, var_name, ub, precision),
         VariableType::DoubleBound(lb, ub) => write_double_bound(output, var_name, lb, ub, precision),
-        VariableType::Binary => write_bound_flag(output, "BV", var_name),
+        VariableType::Binary => {
+            write_bound_flag(output, "BV", var_name).expect("fmt::Write to String is infallible");
+            Ok(())
+        }
         // General has no MPS analogue: both collapse to an integer column
         // with an explicit LO 0 (see module docs).
-        VariableType::Integer | VariableType::General => write_bound_value(output, "LO", var_name, 0.0, precision),
-        VariableType::SemiContinuous => write_bound_value(output, "SC", var_name, SEMI_CONTINUOUS_SENTINEL_UPPER, precision),
+        VariableType::Integer | VariableType::General => {
+            write_bound_value(output, "LO", var_name, 0.0, precision).expect("fmt::Write to String is infallible");
+            Ok(())
+        }
+        VariableType::SemiContinuous => {
+            write_bound_value(output, "SC", var_name, SEMI_CONTINUOUS_SENTINEL_UPPER, precision)
+                .expect("fmt::Write to String is infallible");
+            Ok(())
+        }
         // SOS-membership is not an explicit bound; leave the MPS default
         // ([0, +inf)) in place, matching the LP writer's treatment.
         VariableType::SOS => Ok(()),
     }
+}
+
+/// Write the bound line for a `LowerBound(lb)` variable.
+///
+/// The MPS reader maps a bare `MI`-only bound to `LowerBound(-inf)`, so that
+/// case is written back as `MI` rather than fed to [`write_number`] (which
+/// requires a finite value).
+///
+/// # Errors
+///
+/// Returns an error if `lb` is `NaN`, or `+inf` (a lower bound of `+inf` is
+/// nonsensical -- it would leave the variable with an empty feasible region
+/// unless the upper bound is also `+inf`, which is not representable as a
+/// plain `LowerBound`).
+fn write_lower_bound(output: &mut String, var_name: &str, lb: f64, precision: usize) -> LpResult<()> {
+    if lb.is_nan() {
+        return Err(invalid_bound_error(var_name, "has a NaN lower bound, which MPS cannot represent"));
+    }
+    if lb == f64::INFINITY {
+        return Err(invalid_bound_error(var_name, "has a lower bound of +inf, which MPS cannot represent"));
+    }
+    if lb == f64::NEG_INFINITY {
+        write_bound_flag(output, "MI", var_name).expect("fmt::Write to String is infallible");
+        return Ok(());
+    }
+    write_bound_value(output, "LO", var_name, lb, precision).expect("fmt::Write to String is infallible");
+    Ok(())
 }
 
 /// Write the bound line for an `UpperBound(ub)` variable.
@@ -383,11 +436,33 @@ fn write_variable_bound(output: &mut String, var_name: &str, var_type: &Variable
 /// value and no preceding `LO` implies a lower bound of `-inf`, not the `0`
 /// that `UpperBound` means in this model -- without the explicit `LO 0` the
 /// round trip would silently widen the feasible region.
-fn write_upper_bound(output: &mut String, var_name: &str, ub: f64, precision: usize) -> std::fmt::Result {
-    if ub < 0.0 {
-        write_bound_value(output, "LO", var_name, 0.0, precision)?;
+///
+/// The MPS reader maps a bare `PL`-only bound to `UpperBound(+inf)`, so that
+/// case is written back as `PL` rather than fed to [`write_number`] (which
+/// requires a finite value).
+///
+/// # Errors
+///
+/// Returns an error if `ub` is `NaN`, or `-inf` (an upper bound of `-inf` is
+/// nonsensical -- it would leave the variable with an empty feasible region
+/// unless the lower bound is also `-inf`, which is not representable as a
+/// plain `UpperBound`).
+fn write_upper_bound(output: &mut String, var_name: &str, ub: f64, precision: usize) -> LpResult<()> {
+    if ub.is_nan() {
+        return Err(invalid_bound_error(var_name, "has a NaN upper bound, which MPS cannot represent"));
     }
-    write_bound_value(output, "UP", var_name, ub, precision)
+    if ub == f64::NEG_INFINITY {
+        return Err(invalid_bound_error(var_name, "has an upper bound of -inf, which MPS cannot represent"));
+    }
+    if ub == f64::INFINITY {
+        write_bound_flag(output, "PL", var_name).expect("fmt::Write to String is infallible");
+        return Ok(());
+    }
+    if ub < 0.0 {
+        write_bound_value(output, "LO", var_name, 0.0, precision).expect("fmt::Write to String is infallible");
+    }
+    write_bound_value(output, "UP", var_name, ub, precision).expect("fmt::Write to String is infallible");
+    Ok(())
 }
 
 /// Write the bound line(s) for a `DoubleBound(lb, ub)` variable, collapsing
@@ -400,35 +475,57 @@ fn write_upper_bound(output: &mut String, var_name: &str, ub: f64, precision: us
 /// as `DoubleBound(lb, +inf)` again. Omitting `PL` would leave the upper
 /// bound unset, and the reader would collapse the result to a plain
 /// `LowerBound(lb)` -- semantically identical, but a different variant.
-fn write_double_bound(output: &mut String, var_name: &str, lb: f64, ub: f64, precision: usize) -> std::fmt::Result {
+///
+/// # Errors
+///
+/// Returns an error if either bound is `NaN`, or if `lb` is `+inf` or `ub`
+/// is `-inf` (nonsensical combinations that MPS's `FR`/`MI`/`PL` flags
+/// cannot represent).
+fn write_double_bound(output: &mut String, var_name: &str, lb: f64, ub: f64, precision: usize) -> LpResult<()> {
+    if lb.is_nan() || ub.is_nan() {
+        return Err(invalid_bound_error(var_name, "has a NaN double bound, which MPS cannot represent"));
+    }
+    if lb == f64::INFINITY || ub == f64::NEG_INFINITY {
+        return Err(invalid_bound_error(
+            var_name,
+            &format!("has a nonsensical double bound ({lb}, {ub}), which MPS cannot represent"),
+        ));
+    }
+
     #[allow(clippy::float_cmp)]
     if lb == ub {
-        return write_bound_value(output, "FX", var_name, lb, precision);
+        write_bound_value(output, "FX", var_name, lb, precision).expect("fmt::Write to String is infallible");
+        return Ok(());
     }
     match (lb.is_infinite() && lb < 0.0, ub.is_infinite() && ub > 0.0) {
-        (true, true) => write_bound_flag(output, "FR", var_name),
+        (true, true) => write_bound_flag(output, "FR", var_name).expect("fmt::Write to String is infallible"),
         (true, false) => {
-            write_bound_flag(output, "MI", var_name)?;
-            write_bound_value(output, "UP", var_name, ub, precision)
+            write_bound_flag(output, "MI", var_name).expect("fmt::Write to String is infallible");
+            write_bound_value(output, "UP", var_name, ub, precision).expect("fmt::Write to String is infallible");
         }
         (false, true) => {
-            write_bound_value(output, "LO", var_name, lb, precision)?;
-            write_bound_flag(output, "PL", var_name)
+            write_bound_value(output, "LO", var_name, lb, precision).expect("fmt::Write to String is infallible");
+            write_bound_flag(output, "PL", var_name).expect("fmt::Write to String is infallible");
         }
         (false, false) => {
-            write_bound_value(output, "LO", var_name, lb, precision)?;
-            write_bound_value(output, "UP", var_name, ub, precision)
+            write_bound_value(output, "LO", var_name, lb, precision).expect("fmt::Write to String is infallible");
+            write_bound_value(output, "UP", var_name, ub, precision).expect("fmt::Write to String is infallible");
         }
     }
+    Ok(())
 }
 
 /// Write the `BOUNDS` section, one entry per variable (in declaration order).
-fn write_bounds_section(output: &mut String, problem: &LpProblem, options: &MpsWriterOptions) -> std::fmt::Result {
+///
+/// # Errors
+///
+/// See [`write_variable_bound`].
+fn write_bounds_section(output: &mut String, problem: &LpProblem, options: &MpsWriterOptions) -> LpResult<()> {
     if problem.variables.is_empty() {
         return Ok(());
     }
 
-    writeln!(output, "BOUNDS")?;
+    writeln!(output, "BOUNDS").expect("fmt::Write to String is infallible");
     for (name_id, variable) in &problem.variables {
         let var_name = problem.resolve(*name_id);
         write_variable_bound(output, var_name, &variable.var_type, options.decimal_precision)?;
@@ -715,6 +812,145 @@ mod tests {
         let reparsed = LpProblem::parse_mps(&output).unwrap();
         let x1 = &reparsed.variables[&reparsed.name_id("x1").unwrap()];
         assert_eq!(x1.var_type, VariableType::UpperBound(SEMI_CONTINUOUS_SENTINEL_UPPER));
+    }
+
+    #[test]
+    fn pl_only_bound_round_trips_as_upper_bound_infinity() {
+        // A `PL`-only bound (no `LO`) resolves to `UpperBound(+inf)` on
+        // parse; the writer must emit it back as a bare `PL`, not feed
+        // `+inf` to `write_number` (regression test for the panic/invalid
+        // `UP BOUND x inf` output this used to produce).
+        let input = "\
+NAME        pltest
+ROWS
+ N  obj
+ L  c1
+COLUMNS
+    x1        obj       1
+    x1        c1        1
+RHS
+    RHS_V     c1        10
+BOUNDS
+ PL BOUND     x1
+ENDATA
+";
+        let problem = LpProblem::parse_mps(input).unwrap();
+        let x1 = &problem.variables[&problem.name_id("x1").unwrap()];
+        assert_eq!(x1.var_type, VariableType::UpperBound(f64::INFINITY));
+
+        let output = write_mps_string(&problem).unwrap();
+        assert!(output.contains(" PL BOUND"));
+        assert!(!output.contains("inf"), "must not leak a raw `inf` literal into the bounds line");
+
+        let reparsed = LpProblem::parse_mps(&output).unwrap();
+        let x1 = &reparsed.variables[&reparsed.name_id("x1").unwrap()];
+        assert_eq!(x1.var_type, VariableType::UpperBound(f64::INFINITY));
+    }
+
+    #[test]
+    fn mi_only_bound_round_trips_as_lower_bound_negative_infinity() {
+        // Mirror of the `PL`-only case: an `MI`-only bound resolves to
+        // `LowerBound(-inf)` on parse and must be written back as a bare
+        // `MI`.
+        let input = "\
+NAME        mitest
+ROWS
+ N  obj
+ L  c1
+COLUMNS
+    x1        obj       1
+    x1        c1        1
+RHS
+    RHS_V     c1        10
+BOUNDS
+ MI BOUND     x1
+ENDATA
+";
+        let problem = LpProblem::parse_mps(input).unwrap();
+        let x1 = &problem.variables[&problem.name_id("x1").unwrap()];
+        assert_eq!(x1.var_type, VariableType::LowerBound(f64::NEG_INFINITY));
+
+        let output = write_mps_string(&problem).unwrap();
+        assert!(output.contains(" MI BOUND"));
+        assert!(!output.contains("inf"), "must not leak a raw `inf` literal into the bounds line");
+
+        let reparsed = LpProblem::parse_mps(&output).unwrap();
+        let x1 = &reparsed.variables[&reparsed.name_id("x1").unwrap()];
+        assert_eq!(x1.var_type, VariableType::LowerBound(f64::NEG_INFINITY));
+    }
+
+    #[test]
+    fn nan_upper_bound_returns_validation_error() {
+        let mut problem = LpProblem::new();
+        let obj_id = problem.intern("obj");
+        let x1_id = problem.intern("x1");
+        problem.add_objective(Objective { name: obj_id, coefficients: vec![Coefficient { name: x1_id, value: 1.0 }], byte_offset: None });
+        problem.update_variable_type("x1", VariableType::UpperBound(f64::NAN)).unwrap();
+
+        let err = write_mps_string(&problem).unwrap_err();
+        assert!(matches!(err, LpParseError::ValidationError { .. }));
+    }
+
+    #[test]
+    fn nan_lower_bound_returns_validation_error() {
+        let mut problem = LpProblem::new();
+        let obj_id = problem.intern("obj");
+        let x1_id = problem.intern("x1");
+        problem.add_objective(Objective { name: obj_id, coefficients: vec![Coefficient { name: x1_id, value: 1.0 }], byte_offset: None });
+        problem.update_variable_type("x1", VariableType::LowerBound(f64::NAN)).unwrap();
+
+        let err = write_mps_string(&problem).unwrap_err();
+        assert!(matches!(err, LpParseError::ValidationError { .. }));
+    }
+
+    #[test]
+    fn nonsensical_upper_bound_negative_infinity_returns_validation_error() {
+        let mut problem = LpProblem::new();
+        let obj_id = problem.intern("obj");
+        let x1_id = problem.intern("x1");
+        problem.add_objective(Objective { name: obj_id, coefficients: vec![Coefficient { name: x1_id, value: 1.0 }], byte_offset: None });
+        problem.update_variable_type("x1", VariableType::UpperBound(f64::NEG_INFINITY)).unwrap();
+
+        let err = write_mps_string(&problem).unwrap_err();
+        assert!(matches!(err, LpParseError::ValidationError { .. }));
+    }
+
+    #[test]
+    fn nonsensical_lower_bound_positive_infinity_returns_validation_error() {
+        let mut problem = LpProblem::new();
+        let obj_id = problem.intern("obj");
+        let x1_id = problem.intern("x1");
+        problem.add_objective(Objective { name: obj_id, coefficients: vec![Coefficient { name: x1_id, value: 1.0 }], byte_offset: None });
+        problem.update_variable_type("x1", VariableType::LowerBound(f64::INFINITY)).unwrap();
+
+        let err = write_mps_string(&problem).unwrap_err();
+        assert!(matches!(err, LpParseError::ValidationError { .. }));
+    }
+
+    #[test]
+    fn nan_double_bound_returns_validation_error() {
+        let mut problem = LpProblem::new();
+        let obj_id = problem.intern("obj");
+        let x1_id = problem.intern("x1");
+        problem.add_objective(Objective { name: obj_id, coefficients: vec![Coefficient { name: x1_id, value: 1.0 }], byte_offset: None });
+        problem.update_variable_type("x1", VariableType::DoubleBound(f64::NAN, 5.0)).unwrap();
+
+        let err = write_mps_string(&problem).unwrap_err();
+        assert!(matches!(err, LpParseError::ValidationError { .. }));
+    }
+
+    #[test]
+    fn nonsensical_double_bound_returns_validation_error() {
+        let mut problem = LpProblem::new();
+        let obj_id = problem.intern("obj");
+        let x1_id = problem.intern("x1");
+        problem.add_objective(Objective { name: obj_id, coefficients: vec![Coefficient { name: x1_id, value: 1.0 }], byte_offset: None });
+        // Lower bound of +inf paired with a finite upper bound is an empty,
+        // unrepresentable feasible region.
+        problem.update_variable_type("x1", VariableType::DoubleBound(f64::INFINITY, 5.0)).unwrap();
+
+        let err = write_mps_string(&problem).unwrap_err();
+        assert!(matches!(err, LpParseError::ValidationError { .. }));
     }
 
     #[test]

--- a/rust/src/mps/writer.rs
+++ b/rust/src/mps/writer.rs
@@ -72,6 +72,18 @@
 //!   keeps it correct at the cost of re-parsing as `DoubleBound(0, ub)`
 //!   rather than `UpperBound(ub)` (the same feasible region, a different
 //!   variant).
+//! - **Free-default conversion caveat**: [`LpProblem`] defaults an
+//!   undeclared variable that only appears in constraints (never in a
+//!   `Bounds`/`Free`/etc. section, and never given an explicit bound) to
+//!   [`VariableType::Free`], which this writer faithfully emits as an `FR`
+//!   bound. LP format's own default for such a variable is `[0, +inf)`, not
+//!   free -- so converting an LP file straight through this writer without
+//!   ever having declared the variable's bounds widens its feasible region
+//!   to include negative values. This is not a writer bug (the LP-side
+//!   default is deliberately preserved rather than silently narrowed back
+//!   down), but it is a real semantic difference to be aware of when the
+//!   MPS output feeds another solver: declare bounds explicitly in the LP
+//!   source (even a redundant `x >= 0`) if the distinction matters.
 
 use std::fmt::Write;
 
@@ -486,10 +498,7 @@ fn write_double_bound(output: &mut String, var_name: &str, lb: f64, ub: f64, pre
         return Err(invalid_bound_error(var_name, "has a NaN double bound, which MPS cannot represent"));
     }
     if lb == f64::INFINITY || ub == f64::NEG_INFINITY {
-        return Err(invalid_bound_error(
-            var_name,
-            &format!("has a nonsensical double bound ({lb}, {ub}), which MPS cannot represent"),
-        ));
+        return Err(invalid_bound_error(var_name, &format!("has a nonsensical double bound ({lb}, {ub}), which MPS cannot represent")));
     }
 
     #[allow(clippy::float_cmp)]

--- a/rust/src/mps/writer.rs
+++ b/rust/src/mps/writer.rs
@@ -287,7 +287,12 @@ fn build_columns<'p>(problem: &'p LpProblem, objective: Option<&'p Objective>, o
 
 /// Write the `COLUMNS` section, wrapping integer/general/binary variables in
 /// `'MARKER'` `INTORG`/`INTEND` blocks.
-fn write_columns_section(output: &mut String, problem: &LpProblem, columns: &ColumnEntries<'_>, options: &MpsWriterOptions) -> std::fmt::Result {
+fn write_columns_section(
+    output: &mut String,
+    problem: &LpProblem,
+    columns: &ColumnEntries<'_>,
+    options: &MpsWriterOptions,
+) -> std::fmt::Result {
     writeln!(output, "COLUMNS")?;
 
     for (name_id, variable) in &problem.variables {
@@ -460,8 +465,8 @@ fn write_sos_section(output: &mut String, problem: &LpProblem, options: &MpsWrit
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
-    use crate::mps::parse_mps;
     use crate::model::{Coefficient, ComparisonOp, SOSType};
+    use crate::mps::parse_mps;
 
     fn build_problem_with_bounds_and_sos() -> LpProblem {
         let mut problem = LpProblem::new().with_problem_name(String::from("Sample")).with_sense(Sense::Maximize);

--- a/rust/src/mps/writer.rs
+++ b/rust/src/mps/writer.rs
@@ -1,0 +1,761 @@
+//! MPS file writing and formatting utilities.
+//!
+//! This module writes an [`LpProblem`](crate::problem::LpProblem) back out in
+//! MPS (Mathematical Programming System) format, mirroring the conventions of
+//! the LP writer ([`crate::writer`]): a small options struct,
+//! [`write_mps_string`](crate::mps::writer::write_mps_string) /
+//! [`write_mps_string_with_options`](crate::mps::writer::write_mps_string_with_options)
+//! entry points, and
+//! a private tree of per-section builder functions. Output produced here is
+//! designed to be read back by [`crate::mps::parse_mps`].
+//!
+//! # Formatting
+//!
+//! Output is **free-format** MPS: fields are whitespace-separated and padded
+//! for readability rather than aligned to the strict fixed-column positions
+//! of historical MPS. The reader (like most modern MPS parsers) only ever
+//! splits on whitespace, so this is a purely cosmetic choice.
+//!
+//! # Sections emitted
+//!
+//! `NAME`, `OBJSENSE` (only when the sense is `Maximize` -- `Minimize` is the
+//! MPS default and is left implicit), `ROWS`, `COLUMNS` (integer/general/binary
+//! variables wrapped in `'MARKER'` `INTORG`/`INTEND` blocks), `RHS`, `BOUNDS`,
+//! `SOS`, `ENDATA`.
+//!
+//! No `RANGES` section is ever written: [`LpProblem`](crate::problem::LpProblem)
+//! has no first-class notion of a ranged constraint -- the MPS reader
+//! flattens `RANGES` rows into two ordinary constraints at parse time, so
+//! there is nothing to reconstruct a single ranged row from.
+//!
+//! # Objectives
+//!
+//! MPS represents exactly one objective (a single `N` row). If the problem
+//! has more than one objective, [`write_mps_string`](crate::mps::writer::write_mps_string)
+//! returns an error unless
+//! [`allow_multiple_objectives`](crate::mps::writer::MpsWriterOptions::allow_multiple_objectives)
+//! opts in to writing only the first objective (in insertion order). If the
+//! problem has **no** objectives, a single empty `N` row is written under the
+//! name [`EMPTY_OBJECTIVE_ROW_NAME`](crate::mps::writer::EMPTY_OBJECTIVE_ROW_NAME)
+//! -- this is what [`parse_mps`](crate::mps::parse_mps) itself falls back to
+//! when a file has no `N` rows, so the round trip is stable, but note that
+//! re-parsing such a file yields a problem with **one** empty objective
+//! rather than zero: an unavoidable asymmetry given MPS always has an
+//! objective row.
+//!
+//! # Known round-trip limitations
+//!
+//! - [`General`](crate::model::VariableType::General) and
+//!   [`Integer`](crate::model::VariableType::Integer) are both written
+//!   identically (an `INTORG`/`INTEND` marker block plus an explicit `LO 0`
+//!   bound, to avoid falling back to the MPS default integer bounds of
+//!   `[0, 1]`). Re-parsing always yields `Integer`; the `General` designation
+//!   is an LP-format-only distinction that has no MPS analogue.
+//! - [`SemiContinuous`](crate::model::VariableType::SemiContinuous) carries no
+//!   explicit upper bound in this model, but the MPS `SC` bound type requires
+//!   one. A sentinel value
+//!   ([`SEMI_CONTINUOUS_SENTINEL_UPPER`](crate::mps::writer::SEMI_CONTINUOUS_SENTINEL_UPPER))
+//!   is written
+//!   instead. Separately, the MPS reader currently resolves `SC` bounds to
+//!   [`UpperBound`](crate::model::VariableType::UpperBound) rather than
+//!   `SemiContinuous` (a pre-existing reader characteristic, not introduced
+//!   by this writer), so semi-continuous variables do not round trip through
+//!   MPS as `SemiContinuous`.
+//! - Strict inequalities (`ComparisonOp::LT` / `ComparisonOp::GT`) have no MPS
+//!   representation (only `L`/`G`/`E` rows exist); writing a problem with such
+//!   a constraint returns an error.
+//! - [`UpperBound`](crate::model::VariableType::UpperBound) with a negative
+//!   value is written as an explicit `LO 0` followed by `UP`, rather than a
+//!   bare `UP`. Per the MPS (CPLEX) convention the reader implements, a bare
+//!   negative `UP` with no preceding `LO` implies a lower bound of `-inf`,
+//!   which would silently change the feasible region; the explicit `LO 0`
+//!   keeps it correct at the cost of re-parsing as `DoubleBound(0, ub)`
+//!   rather than `UpperBound(ub)` (the same feasible region, a different
+//!   variant).
+
+use std::fmt::Write;
+
+use indexmap::IndexMap;
+
+use crate::error::{LpParseError, LpResult};
+use crate::interner::NameId;
+use crate::model::{ComparisonOp, Constraint, Objective, Sense, VariableType};
+use crate::problem::LpProblem;
+use crate::writer::write_number;
+
+/// Row name used for the objective when the problem has zero objectives.
+///
+/// See the "Objectives" section of the module documentation.
+pub const EMPTY_OBJECTIVE_ROW_NAME: &str = "OBJ";
+
+/// Sentinel upper bound written for [`VariableType::SemiContinuous`] variables,
+/// which carry no explicit upper bound in this model. `1e30` is the
+/// conventional "infinity" sentinel used by CPLEX/Gurobi-style MPS files.
+pub const SEMI_CONTINUOUS_SENTINEL_UPPER: f64 = 1e30;
+
+/// Fixed vector label written in the RHS section (the first field of each
+/// RHS data line). The MPS reader accepts any label; only the first
+/// encountered vector is honoured, so a single constant label is sufficient.
+const RHS_VECTOR_LABEL: &str = "RHS";
+
+/// Fixed vector label written in the BOUNDS section, analogous to
+/// [`RHS_VECTOR_LABEL`].
+const BOUNDS_VECTOR_LABEL: &str = "BOUND";
+
+/// Options for controlling MPS file output format.
+#[derive(Debug, Clone)]
+pub struct MpsWriterOptions {
+    /// Number of decimal places for numeric values (coefficients, RHS, bounds).
+    pub decimal_precision: usize,
+    /// If the problem has more than one objective, write only the first
+    /// (in insertion order) instead of returning an error.
+    pub allow_multiple_objectives: bool,
+}
+
+impl Default for MpsWriterOptions {
+    fn default() -> Self {
+        Self { decimal_precision: 6, allow_multiple_objectives: false }
+    }
+}
+
+/// Write an `LpProblem` to a string in MPS format.
+///
+/// # Errors
+///
+/// Returns an error if the problem has more than one objective (see
+/// [`MpsWriterOptions::allow_multiple_objectives`]) or contains a constraint
+/// with a strict inequality operator (`<` or `>`), neither of which MPS can
+/// represent.
+pub fn write_mps_string(problem: &LpProblem) -> LpResult<String> {
+    write_mps_string_with_options(problem, &MpsWriterOptions::default())
+}
+
+/// Write an `LpProblem` to a string in MPS format with custom options.
+///
+/// # Errors
+///
+/// See [`write_mps_string`].
+pub fn write_mps_string_with_options(problem: &LpProblem, options: &MpsWriterOptions) -> LpResult<String> {
+    let mut output = String::new();
+    build_mps(&mut output, problem, options)?;
+    Ok(output)
+}
+
+/// Build the full MPS document into `output`.
+fn build_mps(output: &mut String, problem: &LpProblem, options: &MpsWriterOptions) -> LpResult<()> {
+    let objective = select_objective(problem, options)?;
+    let obj_row_name: &str = objective.map_or(EMPTY_OBJECTIVE_ROW_NAME, |o| problem.resolve(o.name));
+
+    write_name_line(output, problem).expect("fmt::Write to String is infallible");
+
+    if problem.sense == Sense::Maximize {
+        writeln!(output, "OBJSENSE").expect("fmt::Write to String is infallible");
+        writeln!(output, "    MAX").expect("fmt::Write to String is infallible");
+    }
+
+    write_rows_section(output, problem, obj_row_name)?;
+
+    let columns = build_columns(problem, objective, obj_row_name);
+    write_columns_section(output, problem, &columns, options).expect("fmt::Write to String is infallible");
+
+    write_rhs_section(output, problem, obj_row_name, options).expect("fmt::Write to String is infallible");
+    write_bounds_section(output, problem, options).expect("fmt::Write to String is infallible");
+    write_sos_section(output, problem, options).expect("fmt::Write to String is infallible");
+
+    writeln!(output, "ENDATA").expect("fmt::Write to String is infallible");
+    Ok(())
+}
+
+/// Select the objective to write, applying the single-objective rule.
+///
+/// # Errors
+///
+/// Returns an error if the problem has more than one objective and
+/// `options.allow_multiple_objectives` is `false`.
+fn select_objective<'p>(problem: &'p LpProblem, options: &MpsWriterOptions) -> LpResult<Option<&'p Objective>> {
+    match problem.objectives.len() {
+        0 => Ok(None),
+        1 => Ok(problem.objectives.values().next()),
+        count if options.allow_multiple_objectives => {
+            debug_assert!(count > 1, "count > 1 guaranteed by preceding match arms");
+            Ok(problem.objectives.values().next())
+        }
+        count => Err(LpParseError::validation_error(format!(
+            "MPS format supports a single objective, but the problem has {count} objectives; \
+             set MpsWriterOptions::allow_multiple_objectives to write only the first"
+        ))),
+    }
+}
+
+/// Write the `NAME` section header line.
+fn write_name_line(output: &mut String, problem: &LpProblem) -> std::fmt::Result {
+    match problem.name() {
+        Some(name) => writeln!(output, "NAME          {name}"),
+        None => writeln!(output, "NAME"),
+    }
+}
+
+/// Map a comparison operator to its MPS row type letter.
+///
+/// # Errors
+///
+/// Returns an error for strict inequalities (`<`, `>`), which MPS cannot
+/// represent (only `L`/`G`/`E` rows exist).
+fn row_type_letter(operator: ComparisonOp, constraint_name: &str) -> LpResult<char> {
+    match operator {
+        ComparisonOp::LTE => Ok('L'),
+        ComparisonOp::GTE => Ok('G'),
+        ComparisonOp::EQ => Ok('E'),
+        ComparisonOp::LT | ComparisonOp::GT => Err(LpParseError::validation_error(format!(
+            "constraint '{constraint_name}' uses strict inequality '{operator}', which MPS cannot represent"
+        ))),
+    }
+}
+
+/// Write the `ROWS` section: the objective's `N` row followed by one row per
+/// standard constraint.
+fn write_rows_section(output: &mut String, problem: &LpProblem, obj_row_name: &str) -> LpResult<()> {
+    writeln!(output, "ROWS").expect("fmt::Write to String is infallible");
+    writeln!(output, " N  {obj_row_name}").expect("fmt::Write to String is infallible");
+
+    for constraint in problem.constraints.values() {
+        if let Constraint::Standard { name, operator, .. } = constraint {
+            let resolved_name = problem.resolve(*name);
+            let letter = row_type_letter(*operator, resolved_name)?;
+            writeln!(output, " {letter}  {resolved_name}").expect("fmt::Write to String is infallible");
+        }
+    }
+
+    Ok(())
+}
+
+/// Whether a variable type must be wrapped in an `INTORG`/`INTEND` marker
+/// block in the `COLUMNS` section.
+const fn needs_marker(var_type: &VariableType) -> bool {
+    matches!(var_type, VariableType::Integer | VariableType::General | VariableType::Binary)
+}
+
+/// Per-variable list of (row name, coefficient) pairs, in the order rows are
+/// encountered (objective first, then constraints in insertion order).
+type ColumnEntries<'p> = IndexMap<NameId, Vec<(&'p str, f64)>>;
+
+/// Build the per-variable COLUMNS entries.
+///
+/// Iterates the objective and constraints once (rather than probing every
+/// (variable, row) pair) and groups coefficients by variable, preserving
+/// [`LpProblem::variables`] insertion order.
+///
+/// Variables that require a marker block ([`needs_marker`]) but have no
+/// coefficients anywhere (isolated integer/general/binary variables) still
+/// need at least one COLUMNS entry to be registered as a column and picked
+/// up by the reader's `INTORG`/`INTEND` tracking -- a zero-valued entry
+/// against the objective row is synthesised for them.
+fn build_columns<'p>(problem: &'p LpProblem, objective: Option<&'p Objective>, obj_row_name: &'p str) -> ColumnEntries<'p> {
+    let mut columns: ColumnEntries<'p> = IndexMap::with_capacity(problem.variables.len());
+    for name_id in problem.variables.keys() {
+        columns.insert(*name_id, Vec::new());
+    }
+
+    if let Some(obj) = objective {
+        for coeff in &obj.coefficients {
+            debug_assert!(problem.variables.contains_key(&coeff.name), "objective coefficient must reference a registered variable");
+            columns.entry(coeff.name).or_default().push((obj_row_name, coeff.value));
+        }
+    }
+
+    for constraint in problem.constraints.values() {
+        if let Constraint::Standard { name, coefficients, .. } = constraint {
+            let row_name = problem.resolve(*name);
+            for coeff in coefficients {
+                debug_assert!(problem.variables.contains_key(&coeff.name), "constraint coefficient must reference a registered variable");
+                columns.entry(coeff.name).or_default().push((row_name, coeff.value));
+            }
+        }
+    }
+
+    for (name_id, variable) in &problem.variables {
+        if needs_marker(&variable.var_type) {
+            let entries = columns.entry(*name_id).or_default();
+            if entries.is_empty() {
+                entries.push((obj_row_name, 0.0));
+            }
+        }
+    }
+
+    columns
+}
+
+/// Write the `COLUMNS` section, wrapping integer/general/binary variables in
+/// `'MARKER'` `INTORG`/`INTEND` blocks.
+fn write_columns_section(output: &mut String, problem: &LpProblem, columns: &ColumnEntries<'_>, options: &MpsWriterOptions) -> std::fmt::Result {
+    writeln!(output, "COLUMNS")?;
+
+    for (name_id, variable) in &problem.variables {
+        let entries = columns.get(name_id).map_or([].as_slice(), Vec::as_slice);
+        if entries.is_empty() {
+            // No row references this variable and it doesn't need a marker
+            // block: nothing to emit (it is still registered via BOUNDS).
+            continue;
+        }
+
+        let var_name = problem.resolve(*name_id);
+        let wrap = needs_marker(&variable.var_type);
+
+        if wrap {
+            writeln!(output, "    MARKER                 'MARKER'                 'INTORG'")?;
+        }
+        for &(row_name, value) in entries {
+            write!(output, "    {var_name:<10} {row_name:<10} ")?;
+            write_number(output, value, options.decimal_precision)?;
+            writeln!(output)?;
+        }
+        if wrap {
+            writeln!(output, "    MARKER                 'MARKER'                 'INTEND'")?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Write the `RHS` section. Zero-valued RHS entries are omitted -- the reader
+/// already defaults missing rows to an RHS of zero.
+fn write_rhs_section(output: &mut String, problem: &LpProblem, obj_row_name: &str, options: &MpsWriterOptions) -> std::fmt::Result {
+    debug_assert!(!obj_row_name.is_empty(), "obj_row_name must not be empty");
+    writeln!(output, "RHS")?;
+
+    for constraint in problem.constraints.values() {
+        if let Constraint::Standard { name, rhs, .. } = constraint {
+            if *rhs == 0.0 {
+                continue;
+            }
+            let resolved_name = problem.resolve(*name);
+            write!(output, "    {RHS_VECTOR_LABEL:<10} {resolved_name:<10} ")?;
+            write_number(output, *rhs, options.decimal_precision)?;
+            writeln!(output)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Write a single BOUNDS line with a numeric value.
+fn write_bound_value(output: &mut String, bound_type: &str, var_name: &str, value: f64, precision: usize) -> std::fmt::Result {
+    write!(output, " {bound_type} {BOUNDS_VECTOR_LABEL:<9} {var_name:<10} ")?;
+    write_number(output, value, precision)?;
+    writeln!(output)
+}
+
+/// Write a single BOUNDS line without a numeric value (`FR`, `BV`).
+fn write_bound_flag(output: &mut String, bound_type: &str, var_name: &str) -> std::fmt::Result {
+    writeln!(output, " {bound_type} {BOUNDS_VECTOR_LABEL:<9} {var_name}")
+}
+
+/// Write the bound line(s) for a single variable's [`VariableType`].
+///
+/// See the module documentation for the `Integer`/`General`/`SemiContinuous`
+/// mapping caveats.
+fn write_variable_bound(output: &mut String, var_name: &str, var_type: &VariableType, precision: usize) -> std::fmt::Result {
+    match *var_type {
+        VariableType::Free => write_bound_flag(output, "FR", var_name),
+        VariableType::LowerBound(lb) => write_bound_value(output, "LO", var_name, lb, precision),
+        VariableType::UpperBound(ub) => write_upper_bound(output, var_name, ub, precision),
+        VariableType::DoubleBound(lb, ub) => write_double_bound(output, var_name, lb, ub, precision),
+        VariableType::Binary => write_bound_flag(output, "BV", var_name),
+        // General has no MPS analogue: both collapse to an integer column
+        // with an explicit LO 0 (see module docs).
+        VariableType::Integer | VariableType::General => write_bound_value(output, "LO", var_name, 0.0, precision),
+        VariableType::SemiContinuous => write_bound_value(output, "SC", var_name, SEMI_CONTINUOUS_SENTINEL_UPPER, precision),
+        // SOS-membership is not an explicit bound; leave the MPS default
+        // ([0, +inf)) in place, matching the LP writer's treatment.
+        VariableType::SOS => Ok(()),
+    }
+}
+
+/// Write the bound line for an `UpperBound(ub)` variable.
+///
+/// When `ub` is negative, an explicit `LO 0` is written first. Per the MPS
+/// (CPLEX) convention implemented by the reader, a bare `UP` with a negative
+/// value and no preceding `LO` implies a lower bound of `-inf`, not the `0`
+/// that `UpperBound` means in this model -- without the explicit `LO 0` the
+/// round trip would silently widen the feasible region.
+fn write_upper_bound(output: &mut String, var_name: &str, ub: f64, precision: usize) -> std::fmt::Result {
+    if ub < 0.0 {
+        write_bound_value(output, "LO", var_name, 0.0, precision)?;
+    }
+    write_bound_value(output, "UP", var_name, ub, precision)
+}
+
+/// Write the bound line(s) for a `DoubleBound(lb, ub)` variable, collapsing
+/// to `FX`/`FR`/`MI`/`LO`+`PL` where the general two-line `LO`+`UP` form is
+/// unnecessary.
+///
+/// A finite lower bound paired with an infinite upper bound is written as
+/// `LO` + an explicit `PL` (rather than just `LO` alone): `PL` sets the
+/// accumulated upper bound to `+inf` on read-back, so the pair round-trips
+/// as `DoubleBound(lb, +inf)` again. Omitting `PL` would leave the upper
+/// bound unset, and the reader would collapse the result to a plain
+/// `LowerBound(lb)` -- semantically identical, but a different variant.
+fn write_double_bound(output: &mut String, var_name: &str, lb: f64, ub: f64, precision: usize) -> std::fmt::Result {
+    #[allow(clippy::float_cmp)]
+    if lb == ub {
+        return write_bound_value(output, "FX", var_name, lb, precision);
+    }
+    match (lb.is_infinite() && lb < 0.0, ub.is_infinite() && ub > 0.0) {
+        (true, true) => write_bound_flag(output, "FR", var_name),
+        (true, false) => {
+            write_bound_flag(output, "MI", var_name)?;
+            write_bound_value(output, "UP", var_name, ub, precision)
+        }
+        (false, true) => {
+            write_bound_value(output, "LO", var_name, lb, precision)?;
+            write_bound_flag(output, "PL", var_name)
+        }
+        (false, false) => {
+            write_bound_value(output, "LO", var_name, lb, precision)?;
+            write_bound_value(output, "UP", var_name, ub, precision)
+        }
+    }
+}
+
+/// Write the `BOUNDS` section, one entry per variable (in declaration order).
+fn write_bounds_section(output: &mut String, problem: &LpProblem, options: &MpsWriterOptions) -> std::fmt::Result {
+    if problem.variables.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(output, "BOUNDS")?;
+    for (name_id, variable) in &problem.variables {
+        let var_name = problem.resolve(*name_id);
+        write_variable_bound(output, var_name, &variable.var_type, options.decimal_precision)?;
+    }
+
+    Ok(())
+}
+
+/// Write the `SOS` section, if the problem has any SOS constraints.
+fn write_sos_section(output: &mut String, problem: &LpProblem, options: &MpsWriterOptions) -> std::fmt::Result {
+    let has_sos = problem.constraints.values().any(|c| matches!(c, Constraint::SOS { .. }));
+    if !has_sos {
+        return Ok(());
+    }
+
+    writeln!(output, "SOS")?;
+    for constraint in problem.constraints.values() {
+        if let Constraint::SOS { name, sos_type, weights, .. } = constraint {
+            writeln!(output, " {sos_type} {}", problem.resolve(*name))?;
+            for weight in weights {
+                write!(output, "    {:<10} ", problem.resolve(weight.name))?;
+                write_number(output, weight.value, options.decimal_precision)?;
+                writeln!(output)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+// Coefficients/bounds must round-trip bit-exactly through the writer and
+// reader, so these tests intentionally compare floats strictly.
+#[allow(clippy::float_cmp)]
+mod tests {
+    use super::*;
+    use crate::mps::parse_mps;
+    use crate::model::{Coefficient, ComparisonOp, SOSType};
+
+    fn build_problem_with_bounds_and_sos() -> LpProblem {
+        let mut problem = LpProblem::new().with_problem_name(String::from("Sample")).with_sense(Sense::Maximize);
+
+        let profit_id = problem.intern("profit");
+        let x1_id = problem.intern("x1");
+        let x2_id = problem.intern("x2");
+        let x3_id = problem.intern("x3");
+        let capacity_id = problem.intern("capacity");
+        let sos1_id = problem.intern("sos1");
+
+        problem.add_objective(Objective {
+            name: profit_id,
+            coefficients: vec![
+                Coefficient { name: x1_id, value: 3.0 },
+                Coefficient { name: x2_id, value: 2.0 },
+                Coefficient { name: x3_id, value: 1.0 },
+            ],
+            byte_offset: None,
+        });
+
+        problem.add_constraint(Constraint::Standard {
+            name: capacity_id,
+            coefficients: vec![
+                Coefficient { name: x1_id, value: 1.0 },
+                Coefficient { name: x2_id, value: 1.0 },
+                Coefficient { name: x3_id, value: 1.0 },
+            ],
+            operator: ComparisonOp::LTE,
+            rhs: 100.0,
+            byte_offset: None,
+        });
+
+        problem.update_variable_type("x1", VariableType::Integer).unwrap();
+        problem.update_variable_type("x2", VariableType::DoubleBound(0.0, 50.0)).unwrap();
+        problem.update_variable_type("x3", VariableType::Binary).unwrap();
+
+        problem.add_constraint(Constraint::SOS {
+            name: sos1_id,
+            sos_type: SOSType::S1,
+            weights: vec![Coefficient { name: x1_id, value: 1.0 }, Coefficient { name: x2_id, value: 2.0 }],
+            byte_offset: None,
+        });
+
+        problem
+    }
+
+    #[test]
+    fn test_write_empty_problem() {
+        let problem = LpProblem::new();
+        let result = write_mps_string(&problem).unwrap();
+
+        assert!(result.contains("NAME"));
+        assert!(result.contains(&format!(" N  {EMPTY_OBJECTIVE_ROW_NAME}")));
+        assert!(result.contains("ENDATA"));
+
+        // Documented asymmetry: zero objectives in, one (empty) objective out.
+        let reparsed = LpProblem::parse_mps(&result).unwrap();
+        assert_eq!(reparsed.objective_count(), 1);
+    }
+
+    #[test]
+    fn test_write_simple_problem_and_reparse() {
+        let mut problem = LpProblem::new().with_problem_name(String::from("Test Problem")).with_sense(Sense::Maximize);
+
+        let profit_id = problem.intern("profit");
+        let x1_id = problem.intern("x1");
+        let x2_id = problem.intern("x2");
+        let capacity_id = problem.intern("capacity");
+
+        problem.add_objective(Objective {
+            name: profit_id,
+            coefficients: vec![Coefficient { name: x1_id, value: 3.0 }, Coefficient { name: x2_id, value: 2.0 }],
+            byte_offset: None,
+        });
+        problem.add_constraint(Constraint::Standard {
+            name: capacity_id,
+            coefficients: vec![Coefficient { name: x1_id, value: 1.0 }, Coefficient { name: x2_id, value: 1.0 }],
+            operator: ComparisonOp::LTE,
+            rhs: 100.0,
+            byte_offset: None,
+        });
+
+        let output = write_mps_string(&problem).unwrap();
+        assert!(output.contains("OBJSENSE"));
+        assert!(output.contains("MAX"));
+        assert!(output.contains(" N  profit"));
+        assert!(output.contains(" L  capacity"));
+
+        let reparsed = LpProblem::parse_mps(&output).unwrap();
+        assert_eq!(reparsed.sense, Sense::Maximize);
+        assert_eq!(reparsed.objective_count(), 1);
+        assert_eq!(reparsed.constraint_count(), 1);
+        assert_eq!(reparsed.variable_count(), 2);
+
+        let capacity = reparsed.constraints.get(&reparsed.name_id("capacity").unwrap()).unwrap();
+        if let Constraint::Standard { rhs, operator, .. } = capacity {
+            assert_eq!(*rhs, 100.0);
+            assert_eq!(*operator, ComparisonOp::LTE);
+        } else {
+            panic!("expected Standard constraint");
+        }
+    }
+
+    #[test]
+    fn test_write_bounds_and_integrality_round_trip() {
+        let problem = build_problem_with_bounds_and_sos();
+        let output = write_mps_string(&problem).unwrap();
+
+        assert!(output.contains("MARKER"));
+        assert!(output.contains("INTORG"));
+        assert!(output.contains("INTEND"));
+        assert!(output.contains("BV"));
+        assert!(output.contains("SOS"));
+
+        let reparsed = LpProblem::parse_mps(&output).unwrap();
+        assert_eq!(reparsed.variable_count(), 3);
+        assert_eq!(reparsed.constraint_count(), 2); // 1 standard + 1 SOS
+
+        let x1 = &reparsed.variables[&reparsed.name_id("x1").unwrap()];
+        assert_eq!(x1.var_type, VariableType::Integer);
+
+        let x2 = &reparsed.variables[&reparsed.name_id("x2").unwrap()];
+        assert_eq!(x2.var_type, VariableType::DoubleBound(0.0, 50.0));
+
+        let x3 = &reparsed.variables[&reparsed.name_id("x3").unwrap()];
+        assert_eq!(x3.var_type, VariableType::Binary);
+
+        let sos = reparsed.constraints.get(&reparsed.name_id("sos1").unwrap()).unwrap();
+        if let Constraint::SOS { sos_type, weights, .. } = sos {
+            assert_eq!(*sos_type, SOSType::S1);
+            assert_eq!(weights.len(), 2);
+        } else {
+            panic!("expected SOS constraint");
+        }
+    }
+
+    #[test]
+    fn test_double_bound_infinite_upper_round_trips_as_double_bound() {
+        let mut problem = LpProblem::new();
+        let obj_id = problem.intern("obj");
+        let x1_id = problem.intern("x1");
+        problem.add_objective(Objective { name: obj_id, coefficients: vec![Coefficient { name: x1_id, value: 1.0 }], byte_offset: None });
+        problem.update_variable_type("x1", VariableType::DoubleBound(5.5, f64::INFINITY)).unwrap();
+
+        let output = write_mps_string(&problem).unwrap();
+        assert!(output.contains("PL"));
+
+        let reparsed = LpProblem::parse_mps(&output).unwrap();
+        let x1 = &reparsed.variables[&reparsed.name_id("x1").unwrap()];
+        assert_eq!(x1.var_type, VariableType::DoubleBound(5.5, f64::INFINITY));
+    }
+
+    #[test]
+    fn test_negative_upper_bound_keeps_zero_lower_bound() {
+        let mut problem = LpProblem::new();
+        let obj_id = problem.intern("obj");
+        let x1_id = problem.intern("x1");
+        problem.add_objective(Objective { name: obj_id, coefficients: vec![Coefficient { name: x1_id, value: 1.0 }], byte_offset: None });
+        problem.update_variable_type("x1", VariableType::UpperBound(-5.0)).unwrap();
+
+        let output = write_mps_string(&problem).unwrap();
+
+        let reparsed = LpProblem::parse_mps(&output).unwrap();
+        let x1 = &reparsed.variables[&reparsed.name_id("x1").unwrap()];
+        // Documented variant collapse: same feasible region (lower 0), but
+        // DoubleBound rather than UpperBound (see module docs).
+        assert_eq!(x1.var_type, VariableType::DoubleBound(0.0, -5.0));
+    }
+
+    #[test]
+    fn test_multiple_objectives_error_by_default() {
+        let mut problem = LpProblem::new();
+        let a = problem.intern("a");
+        let b = problem.intern("b");
+        let x1_id = problem.intern("x1");
+        problem.add_objective(Objective { name: a, coefficients: vec![Coefficient { name: x1_id, value: 1.0 }], byte_offset: None });
+        problem.add_objective(Objective { name: b, coefficients: vec![Coefficient { name: x1_id, value: 2.0 }], byte_offset: None });
+
+        let err = write_mps_string(&problem).unwrap_err();
+        assert!(matches!(err, LpParseError::ValidationError { .. }));
+    }
+
+    #[test]
+    fn test_multiple_objectives_allowed_writes_first() {
+        let mut problem = LpProblem::new();
+        let a = problem.intern("a");
+        let b = problem.intern("b");
+        let x1_id = problem.intern("x1");
+        problem.add_objective(Objective { name: a, coefficients: vec![Coefficient { name: x1_id, value: 1.0 }], byte_offset: None });
+        problem.add_objective(Objective { name: b, coefficients: vec![Coefficient { name: x1_id, value: 2.0 }], byte_offset: None });
+
+        let options = MpsWriterOptions { allow_multiple_objectives: true, ..MpsWriterOptions::default() };
+        let output = write_mps_string_with_options(&problem, &options).unwrap();
+
+        let reparsed = LpProblem::parse_mps(&output).unwrap();
+        assert_eq!(reparsed.objective_count(), 1);
+        assert!(reparsed.name_id("a").is_some());
+    }
+
+    #[test]
+    fn test_strict_inequality_returns_error() {
+        let mut problem = LpProblem::new();
+        let x1_id = problem.intern("x1");
+        let c1 = problem.intern("c1");
+        problem.add_constraint(Constraint::Standard {
+            name: c1,
+            coefficients: vec![Coefficient { name: x1_id, value: 1.0 }],
+            operator: ComparisonOp::LT,
+            rhs: 5.0,
+            byte_offset: None,
+        });
+
+        let err = write_mps_string(&problem).unwrap_err();
+        assert!(matches!(err, LpParseError::ValidationError { .. }));
+    }
+
+    #[test]
+    fn test_isolated_integer_variable_registers_as_column() {
+        // A general/integer variable with no coefficients anywhere must still
+        // round-trip as Integer, not fall back to the MPS [0, 1] default.
+        let mut problem = LpProblem::new();
+        let obj_id = problem.intern("obj");
+        problem.add_objective(Objective { name: obj_id, coefficients: vec![], byte_offset: None });
+        let x1_id = problem.intern("x1");
+        problem.add_variable(crate::model::Variable::new(x1_id).with_var_type(VariableType::General));
+
+        let output = write_mps_string(&problem).unwrap();
+        let reparsed = LpProblem::parse_mps(&output).unwrap();
+        let x1 = &reparsed.variables[&reparsed.name_id("x1").unwrap()];
+        assert_eq!(x1.var_type, VariableType::Integer);
+    }
+
+    #[test]
+    fn test_semi_continuous_round_trip_is_lossy_upper_bound() {
+        // Documented limitation: SemiContinuous round-trips as UpperBound.
+        let mut problem = LpProblem::new();
+        let obj_id = problem.intern("obj");
+        problem.add_objective(Objective { name: obj_id, coefficients: vec![], byte_offset: None });
+        let x1_id = problem.intern("x1");
+        problem.add_variable(crate::model::Variable::new(x1_id).with_var_type(VariableType::SemiContinuous));
+
+        let output = write_mps_string(&problem).unwrap();
+        assert!(output.contains("SC"));
+
+        let reparsed = LpProblem::parse_mps(&output).unwrap();
+        let x1 = &reparsed.variables[&reparsed.name_id("x1").unwrap()];
+        assert_eq!(x1.var_type, VariableType::UpperBound(SEMI_CONTINUOUS_SENTINEL_UPPER));
+    }
+
+    #[test]
+    fn mps_round_trip_preserves_mps_fixture() {
+        let input = "\
+NAME        test
+ROWS
+ N  obj
+ L  c1
+ G  c2
+ E  c3
+COLUMNS
+    x1        obj       1
+    x1        c1        2
+    x1        c2        1
+    x1        c3        1
+    x2        obj       2
+    x2        c1        1
+RHS
+    RHS_V     c1        10
+    RHS_V     c2        1
+    RHS_V     c3        4
+BOUNDS
+ LO BOUND     x1        0
+ UP BOUND     x1        20
+ENDATA
+";
+        let original = parse_mps(input).unwrap();
+        let problem = LpProblem::parse_mps(input).unwrap();
+        let output = write_mps_string(&problem).unwrap();
+        let reparsed = LpProblem::parse_mps(&output).unwrap();
+
+        assert_eq!(reparsed.variable_count(), problem.variable_count());
+        assert_eq!(reparsed.constraint_count(), problem.constraint_count());
+        assert_eq!(reparsed.objective_count(), problem.objective_count());
+        assert_eq!(reparsed.sense, problem.sense);
+        assert_eq!(original.constraints.len(), reparsed.constraint_count());
+
+        let x1 = &reparsed.variables[&reparsed.name_id("x1").unwrap()];
+        assert_eq!(x1.var_type, VariableType::DoubleBound(0.0, 20.0));
+    }
+
+    #[test]
+    fn snapshot_representative_problem() {
+        let problem = build_problem_with_bounds_and_sos();
+        let output = write_mps_string(&problem).unwrap();
+        insta::assert_snapshot!(output);
+    }
+}

--- a/rust/src/writer.rs
+++ b/rust/src/writer.rs
@@ -364,8 +364,11 @@ fn write_formatted_coefficient(output: &mut String, name: &str, value: f64, is_f
 /// Write a number with specified precision directly to the output buffer: a bare
 /// integer when the value is whole, small enough (|value| < 1e10) and round-trips
 /// through `i64`; otherwise a decimal with trailing zeros trimmed.
+///
+/// `pub(crate)` so the MPS writer ([`crate::mps::writer`]) can reuse the same
+/// numeric formatting instead of duplicating it.
 #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
-fn write_number(output: &mut String, value: f64, precision: usize) -> std::fmt::Result {
+pub(crate) fn write_number(output: &mut String, value: f64, precision: usize) -> std::fmt::Result {
     debug_assert!(value.is_finite(), "write_number called with non-finite value: {value}");
     let is_whole_number = value.fract().abs() < f64::EPSILON;
     let is_safe_for_i64 = value >= (i64::MIN as f64) && value <= (i64::MAX as f64);

--- a/rust/tests/test_mps_writer.rs
+++ b/rust/tests/test_mps_writer.rs
@@ -1,0 +1,147 @@
+//! Round-trip tests for the MPS writer (`lp_parser_rs::mps::writer`).
+//!
+//! Two directions are exercised:
+//! - MPS -> MPS: every fixture under `resources/mps/` is parsed, written back
+//!   out, and re-parsed, asserting the structural shape is preserved.
+//! - LP -> MPS: a selection of existing LP fixtures (already exercised by
+//!   `test_from_file.rs`) are parsed, converted to MPS, and re-parsed.
+
+// RHS values must round-trip bit-exactly at high decimal precision, so this
+// suite intentionally compares floats strictly.
+#![allow(clippy::float_cmp)]
+
+use std::error::Error;
+use std::fs;
+use std::path::PathBuf;
+
+use lp_parser_rs::model::Constraint;
+use lp_parser_rs::mps::writer::{MpsWriterOptions, write_mps_string_with_options};
+use lp_parser_rs::parser::parse_file;
+use lp_parser_rs::problem::LpProblem;
+
+/// High-precision options so RHS/coefficient round-trip assertions aren't
+/// muddied by the writer's default 6-decimal-place rounding (a formatting
+/// choice, not a correctness bug -- see `LpWriterOptions::decimal_precision`
+/// for the equivalent LP-writer behaviour).
+fn lossless_options() -> MpsWriterOptions {
+    MpsWriterOptions { decimal_precision: 15, ..MpsWriterOptions::default() }
+}
+
+fn resource_path(relative: &str) -> PathBuf {
+    let mut file_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    file_path.push("resources");
+    file_path.push(relative);
+    file_path
+}
+
+fn read_resource(relative: &str) -> Result<String, Box<dyn Error + 'static>> {
+    Ok(parse_file(&resource_path(relative))?)
+}
+
+/// Assert that `reparsed` has the same structural shape as `original`:
+/// sense, objective/constraint/variable counts, and per-variable bounds
+/// (`VariableType`), per-constraint operator and RHS.
+///
+/// Matches variables/constraints by name rather than `NameId` since the two
+/// problems come from independent interners.
+fn assert_round_trip_preserves_structure(original: &LpProblem, reparsed: &LpProblem, context: &str) {
+    assert_eq!(reparsed.sense, original.sense, "{context}: sense mismatch");
+    assert_eq!(reparsed.objective_count(), original.objective_count(), "{context}: objective count mismatch");
+    assert_eq!(reparsed.constraint_count(), original.constraint_count(), "{context}: constraint count mismatch");
+    assert_eq!(reparsed.variable_count(), original.variable_count(), "{context}: variable count mismatch");
+
+    for (name_id, var) in &original.variables {
+        let name = original.resolve(*name_id);
+        let reparsed_id = reparsed.name_id(name).unwrap_or_else(|| panic!("{context}: variable '{name}' missing after round trip"));
+        let reparsed_var = &reparsed.variables[&reparsed_id];
+        assert_eq!(reparsed_var.var_type, var.var_type, "{context}: bound/type mismatch for variable '{name}'");
+    }
+
+    for (name_id, constraint) in &original.constraints {
+        let name = original.resolve(*name_id);
+        let reparsed_id = reparsed.name_id(name).unwrap_or_else(|| panic!("{context}: constraint '{name}' missing after round trip"));
+        let reparsed_constraint = reparsed.constraints.get(&reparsed_id).unwrap_or_else(|| panic!("{context}: constraint '{name}' vanished"));
+
+        match (constraint, reparsed_constraint) {
+            (Constraint::Standard { operator: op1, rhs: rhs1, .. }, Constraint::Standard { operator: op2, rhs: rhs2, .. }) => {
+                assert_eq!(op2, op1, "{context}: operator mismatch for constraint '{name}'");
+                assert_eq!(rhs2, rhs1, "{context}: RHS mismatch for constraint '{name}'");
+            }
+            (Constraint::SOS { sos_type: t1, weights: w1, .. }, Constraint::SOS { sos_type: t2, weights: w2, .. }) => {
+                assert_eq!(t2, t1, "{context}: SOS type mismatch for constraint '{name}'");
+                assert_eq!(w2.len(), w1.len(), "{context}: SOS weight count mismatch for constraint '{name}'");
+            }
+            _ => panic!("{context}: constraint kind mismatch for '{name}'"),
+        }
+    }
+}
+
+/// Every fixture under `resources/mps/` should survive a full
+/// parse -> write -> re-parse round trip with its structure intact.
+#[test]
+fn mps_fixtures_round_trip_through_writer() {
+    let dir = resource_path("mps");
+    let mut fixtures: Vec<PathBuf> = fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", dir.display()))
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|path| path.extension().is_some_and(|ext| ext.eq_ignore_ascii_case("mps")))
+        .collect();
+    fixtures.sort();
+    assert!(!fixtures.is_empty(), "expected at least one .mps fixture under {}", dir.display());
+
+    for path in fixtures {
+        let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("<unknown>").to_string();
+        let input = parse_file(&path).unwrap_or_else(|e| panic!("failed to read {file_name}: {e}"));
+        let original = LpProblem::parse_mps(&input).unwrap_or_else(|e| panic!("failed to parse {file_name}: {e}"));
+
+        let output = write_mps_string_with_options(&original, &lossless_options()).unwrap_or_else(|e| panic!("failed to write {file_name} as MPS: {e}"));
+        let reparsed = LpProblem::parse_mps(&output).unwrap_or_else(|e| panic!("failed to re-parse written {file_name}:\n{output}\n\nerror: {e}"));
+
+        assert_round_trip_preserves_structure(&original, &reparsed, &file_name);
+    }
+}
+
+/// A selection of existing single-objective, non-strict-inequality LP
+/// fixtures (already exercised by `test_from_file.rs`) round-tripped through
+/// the MPS writer.
+#[test]
+fn lp_fixtures_round_trip_through_mps_writer() {
+    let fixtures = [
+        "pulp.lp",
+        "pulp2.lp",
+        "limbo.lp",
+        "sos.lp",
+        // "test.lp" is deliberately excluded: it contains a strict inequality
+        // (`c3:: x2 > 1`), which MPS cannot represent -- see
+        // `lp_fixture_with_strict_inequality_is_rejected` below.
+        "test2.lp",
+        "empty_bounds.lp",
+        "blank_lines.lp",
+        "infile_comments.lp",
+        "infile_comments2.lp",
+        "missing_signs.lp",
+        "fit2d.lp",
+    ];
+
+    for file_name in fixtures {
+        let input = read_resource(file_name).unwrap_or_else(|e| panic!("failed to read {file_name}: {e}"));
+        let original = LpProblem::parse(&input).unwrap_or_else(|e| panic!("failed to parse {file_name}: {e}"));
+
+        let output = write_mps_string_with_options(&original, &lossless_options()).unwrap_or_else(|e| panic!("failed to write {file_name} as MPS: {e}"));
+        let reparsed = LpProblem::parse_mps(&output).unwrap_or_else(|e| panic!("failed to re-parse written {file_name}:\n{output}\n\nerror: {e}"));
+
+        assert_round_trip_preserves_structure(&original, &reparsed, file_name);
+    }
+}
+
+/// `test.lp` contains a strict inequality (`c3:: x2 > 1`), which MPS has no
+/// row type for; writing it must return an error rather than silently
+/// downgrading the operator.
+#[test]
+fn lp_fixture_with_strict_inequality_is_rejected() {
+    let input = read_resource("test.lp").unwrap_or_else(|e| panic!("failed to read test.lp: {e}"));
+    let problem = LpProblem::parse(&input).unwrap_or_else(|e| panic!("failed to parse test.lp: {e}"));
+
+    let err = write_mps_string_with_options(&problem, &lossless_options()).unwrap_err();
+    assert!(err.to_string().contains("strict inequality"), "unexpected error: {err}");
+}

--- a/rust/tests/test_mps_writer.rs
+++ b/rust/tests/test_mps_writer.rs
@@ -60,7 +60,8 @@ fn assert_round_trip_preserves_structure(original: &LpProblem, reparsed: &LpProb
     for (name_id, constraint) in &original.constraints {
         let name = original.resolve(*name_id);
         let reparsed_id = reparsed.name_id(name).unwrap_or_else(|| panic!("{context}: constraint '{name}' missing after round trip"));
-        let reparsed_constraint = reparsed.constraints.get(&reparsed_id).unwrap_or_else(|| panic!("{context}: constraint '{name}' vanished"));
+        let reparsed_constraint =
+            reparsed.constraints.get(&reparsed_id).unwrap_or_else(|| panic!("{context}: constraint '{name}' vanished"));
 
         match (constraint, reparsed_constraint) {
             (Constraint::Standard { operator: op1, rhs: rhs1, .. }, Constraint::Standard { operator: op2, rhs: rhs2, .. }) => {
@@ -94,8 +95,10 @@ fn mps_fixtures_round_trip_through_writer() {
         let input = parse_file(&path).unwrap_or_else(|e| panic!("failed to read {file_name}: {e}"));
         let original = LpProblem::parse_mps(&input).unwrap_or_else(|e| panic!("failed to parse {file_name}: {e}"));
 
-        let output = write_mps_string_with_options(&original, &lossless_options()).unwrap_or_else(|e| panic!("failed to write {file_name} as MPS: {e}"));
-        let reparsed = LpProblem::parse_mps(&output).unwrap_or_else(|e| panic!("failed to re-parse written {file_name}:\n{output}\n\nerror: {e}"));
+        let output = write_mps_string_with_options(&original, &lossless_options())
+            .unwrap_or_else(|e| panic!("failed to write {file_name} as MPS: {e}"));
+        let reparsed =
+            LpProblem::parse_mps(&output).unwrap_or_else(|e| panic!("failed to re-parse written {file_name}:\n{output}\n\nerror: {e}"));
 
         assert_round_trip_preserves_structure(&original, &reparsed, &file_name);
     }
@@ -127,8 +130,10 @@ fn lp_fixtures_round_trip_through_mps_writer() {
         let input = read_resource(file_name).unwrap_or_else(|e| panic!("failed to read {file_name}: {e}"));
         let original = LpProblem::parse(&input).unwrap_or_else(|e| panic!("failed to parse {file_name}: {e}"));
 
-        let output = write_mps_string_with_options(&original, &lossless_options()).unwrap_or_else(|e| panic!("failed to write {file_name} as MPS: {e}"));
-        let reparsed = LpProblem::parse_mps(&output).unwrap_or_else(|e| panic!("failed to re-parse written {file_name}:\n{output}\n\nerror: {e}"));
+        let output = write_mps_string_with_options(&original, &lossless_options())
+            .unwrap_or_else(|e| panic!("failed to write {file_name} as MPS: {e}"));
+        let reparsed =
+            LpProblem::parse_mps(&output).unwrap_or_else(|e| panic!("failed to re-parse written {file_name}:\n{output}\n\nerror: {e}"));
 
         assert_round_trip_preserves_structure(&original, &reparsed, file_name);
     }

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lp_parser_tui"
 version = "3.5.0"
 edition = "2024"
-description = "Interactive TUI diff viewer for LP files"
+description = "Interactive TUI model explorer and diff viewer for LP/MPS files"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dandxy89/lp_parser_rs"
 keywords = ["lp", "parser", "tui", "diff"]
@@ -13,7 +13,7 @@ name = "lp_diff"
 path = "src/main.rs"
 
 [dependencies]
-lp_parser_rs = { path = "../rust", features = ["diff", "serde", "mmap"] }
+lp_parser_rs = { path = "../rust", features = ["csv", "diff", "serde", "mmap"] }
 
 arboard = "3.6.1"
 chrono = "0.4.45"

--- a/tui/README.md
+++ b/tui/README.md
@@ -1,6 +1,6 @@
-# lp_diff — Interactive LP/MPS File Diff Viewer
+# lp_diff — LP/MPS Model Explorer and Diff Viewer
 
-A terminal-based interactive diff viewer for Linear Programming files (LP and MPS formats), built with [ratatui](https://ratatui.rs).
+A terminal-based interactive explorer and diff viewer for Linear Programming files (LP and MPS formats), built with [ratatui](https://ratatui.rs). Pass one file to explore a single model, or two files to diff them.
 
 ![lp_diff demo](assets/demo.gif)
 
@@ -20,6 +20,14 @@ cargo run -p lp_parser_tui -- file1.lp file2.mps
 
 ## Usage
 
+Inspect a single model:
+
+```sh
+lp_diff model.lp
+```
+
+Diff two files:
+
 ```sh
 lp_diff base.lp modified.lp
 ```
@@ -30,14 +38,25 @@ Both LP (`.lp`) and MPS (`.mps`) formats are supported. You can even mix formats
 lp_diff model.lp model.mps
 ```
 
-The viewer parses both files, computes a rich diff report, and launches an interactive TUI. Format is detected automatically by file extension.
+With one file the viewer parses it and launches a single-model explorer (inspect mode); with two files it computes a rich diff report and launches the diff viewer. Format is detected automatically by file extension.
+
+### Inspect Mode (single file)
+
+Given one file, the same five sections describe the single model rather than a comparison:
+
+- **Summary** — file path, problem name, sense, per-section counts, and the structural analysis (dimensions, variable/constraint types, coefficient scaling, issues).
+- **Variables / Constraints / Objectives** — every entry in the model, listed plainly (no diff badges). The detail panel shows the full entry: coefficients with names, operator and RHS, bounds and variable type, or SOS weights.
+- **Numerics** — the per-file numerical conditioning view.
+
+Search (`/`), the command palette (`Ctrl+p`), sort by name, the HiGHS solver (`S`, solving the single model directly), CSV export (`w`, writing `objectives.csv`, `constraints.csv`, `variables.csv` via the core library), and `--watch` all work. Diff-only actions — kind filters (`a`/`+`/`-`/`m`/`=`), ignore-order (`o`), tolerance cycling (`t`/`T`), delta sorts, and the raw side-by-side view (`r`) — are hidden from the help/palette and no-op with a brief status-bar hint if pressed.
 
 ### Summary Mode
 
-For non-interactive output, use the `--summary` flag to print a structured text report to stdout and exit:
+For non-interactive output, use the `--summary` flag to print a structured text report to stdout and exit. In diff mode it prints the change summary; in inspect mode it prints the model counts and top analysis issues:
 
 ```sh
-lp_diff base.lp modified.lp --summary
+lp_diff base.lp modified.lp --summary   # diff summary
+lp_diff model.lp --summary              # single-model summary
 ```
 
 Output format:
@@ -86,7 +105,7 @@ Press `r` in the detail panel to toggle between the parsed diff view and a side-
 
 ### CSV Export
 
-Press `w` to export the full diff report as a CSV file (`lp_diff_report_<timestamp>.csv`) in the current directory. The CSV includes all sections with columns for section, name, change type, and detail.
+In diff mode, press `w` to export the full diff report as a CSV file (`lp_diff_report_<timestamp>.csv`) in the current directory. The CSV includes all sections with columns for section, name, change type, and detail. In inspect mode, `w` exports the model itself as `objectives.csv`, `constraints.csv`, and `variables.csv` (via the core library's `to_csv`).
 
 ### Key Bindings
 

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -1304,8 +1304,11 @@ impl App {
 
     /// Rebuild the cached styled lines for the current search results.
     fn rebuild_search_result_lines(&mut self) {
-        self.search_popup.cached_result_lines =
-            crate::widgets::search_popup::build_result_lines(&self.search_popup.results, &self.search_name_buffer);
+        self.search_popup.cached_result_lines = crate::widgets::search_popup::build_result_lines(
+            &self.search_popup.results,
+            &self.search_name_buffer,
+            self.mode.shows_diff_badges(),
+        );
     }
 
     /// Populate search results with all entries (no query filter).

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -15,8 +15,8 @@ use crate::diff_model::{DiffEntry, DiffInput, DiffKind, DiffOptions, DiffSummary
 use crate::parse::ParsedFile;
 use crate::search::{self, CompiledSearch, SearchMode};
 use crate::solver::{InfeasibilityDiagnosis, SolveResult};
+pub use crate::state::{AppMode, DiffFilter, Focus, SearchResult, Section, SectionViewState};
 use crate::state::{DetailView, DiagnosisState, JumpEntry, JumpList, PendingYank, Side, SolveState, SolveViewState, SortMode};
-pub use crate::state::{DiffFilter, Focus, SearchResult, Section, SectionViewState};
 use crate::watch::{WatchSession, WatchState};
 
 /// State for the `Ctrl+P` command palette overlay.
@@ -155,6 +155,8 @@ impl SolverSession {
 }
 
 pub struct App {
+    /// Diff (two files) or Inspect (single file). Fixed at startup.
+    pub mode: AppMode,
     pub report: LpDiffReport,
     pub active_section: Section,
     pub focus: Focus,
@@ -302,7 +304,23 @@ pub(crate) fn format_tolerance(value: f64) -> String {
     if value == 0.0 { "off".to_owned() } else { format!("{value:e}") }
 }
 
-/// Build pre-computed tab bar labels: list sections carry their change count.
+/// Build the Summary-section lines for the active mode.
+fn build_mode_summary_lines(mode: AppMode, report: &LpDiffReport, summary: &DiffSummary, problem: &LpProblem) -> Vec<Line<'static>> {
+    match mode {
+        AppMode::Diff => crate::widgets::summary::build_summary_lines(report, summary, &report.analysis1, &report.analysis2),
+        AppMode::Inspect => crate::widgets::summary::build_inspect_summary_lines(&report.file1, problem, summary, &report.analysis1),
+    }
+}
+
+/// Build the Numerics-section lines for the active mode.
+fn build_mode_numerics_lines(mode: AppMode, report: &LpDiffReport, _problem: &LpProblem) -> Vec<Line<'static>> {
+    match mode {
+        AppMode::Diff => crate::widgets::numerics::build_numerics_lines(report),
+        AppMode::Inspect => crate::widgets::numerics::build_inspect_numerics_lines(&report.file1, &report.analysis1),
+    }
+}
+
+/// Build pre-computed tab bar labels: list sections carry their entry/change count.
 pub(crate) fn build_section_labels(summary: &DiffSummary) -> [Cow<'static, str>; 5] {
     Section::ALL.map(|section| match section {
         Section::Summary | Section::Numerics => Cow::Borrowed(section.label()),
@@ -313,8 +331,66 @@ pub(crate) fn build_section_labels(summary: &DiffSummary) -> [Cow<'static, str>;
 }
 
 impl App {
+    /// Construct the diff-mode app (two files).
     #[allow(clippy::too_many_arguments)] // constructor mirrors main.rs wiring; a params struct adds noise
     pub fn new(
+        report: LpDiffReport,
+        file1_path: PathBuf,
+        file2_path: PathBuf,
+        problem1: Arc<LpProblem>,
+        problem2: Arc<LpProblem>,
+        raw_text1: Arc<str>,
+        raw_text2: Arc<str>,
+        diff_options: DiffOptions,
+        line_map1: HashMap<NameId, usize>,
+        line_map2: HashMap<NameId, usize>,
+    ) -> Self {
+        Self::build(
+            AppMode::Diff,
+            report,
+            file1_path,
+            file2_path,
+            problem1,
+            problem2,
+            raw_text1,
+            raw_text2,
+            diff_options,
+            line_map1,
+            line_map2,
+        )
+    }
+
+    /// Construct the inspect-mode app (single file).
+    ///
+    /// The unused "file 2" slots are populated from the single file so the shared
+    /// diff-oriented plumbing (solver problems, raw-text lookups, watch mtimes)
+    /// has valid values; inspect-mode presentation never surfaces them as a
+    /// second file.
+    pub fn new_inspect(
+        report: LpDiffReport,
+        file_path: PathBuf,
+        problem: Arc<LpProblem>,
+        raw_text: Arc<str>,
+        line_map: HashMap<NameId, usize>,
+    ) -> Self {
+        Self::build(
+            AppMode::Inspect,
+            report,
+            file_path.clone(),
+            file_path,
+            Arc::clone(&problem),
+            problem,
+            Arc::clone(&raw_text),
+            raw_text,
+            DiffOptions::default(),
+            line_map.clone(),
+            line_map,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)] // constructor mirrors main.rs wiring; a params struct adds noise
+    fn build(
+        mode: AppMode,
         report: LpDiffReport,
         file1_path: PathBuf,
         file2_path: PathBuf,
@@ -333,13 +409,14 @@ impl App {
 
         // Pre-build summary lines once (report data never changes).
         let report_summary = report.summary();
-        let summary_lines = crate::widgets::summary::build_summary_lines(&report, &report_summary, &report.analysis1, &report.analysis2);
-        let numerics_lines = crate::widgets::numerics::build_numerics_lines(&report);
+        let summary_lines = build_mode_summary_lines(mode, &report, &report_summary, &problem1);
+        let numerics_lines = build_mode_numerics_lines(mode, &report, &problem1);
 
         // Pre-compute tab bar labels.
         let section_labels = build_section_labels(&report_summary);
 
         Self {
+            mode,
             report,
             active_section: Section::Summary,
             focus: Focus::SectionSelector,
@@ -396,6 +473,18 @@ impl App {
         }
     }
 
+    /// Flash a transient status-bar message (reuses the yank flash channel).
+    pub(crate) fn flash_status(&mut self, message: impl Into<String>) {
+        self.yank.message = message.into();
+        self.yank.flash = Some(Instant::now());
+    }
+
+    /// A diff-only action was pressed in inspect mode: brief no-op hint.
+    pub(crate) fn flash_diff_only(&mut self) {
+        debug_assert!(matches!(self.mode, AppMode::Inspect), "flash_diff_only is only reachable in inspect mode");
+        self.flash_status("Not available in inspect mode (single file)");
+    }
+
     /// Toggle between parsed and raw text detail views.
     pub const fn toggle_detail_view(&mut self) {
         self.detail_view = match self.detail_view {
@@ -422,8 +511,7 @@ impl App {
                 counts.unchanged += counts.order_only;
             }
         }
-        self.summary_lines =
-            crate::widgets::summary::build_summary_lines(&self.report, &summary, &self.report.analysis1, &self.report.analysis2);
+        self.summary_lines = build_mode_summary_lines(self.mode, &self.report, &summary, &self.problem1);
         self.section_labels = build_section_labels(&summary);
         self.cached_summary = summary;
     }
@@ -478,19 +566,28 @@ impl App {
     /// rebuilding them every keystroke is wasted work. Watch reloads pass
     /// `true` because they install fresh analyses.
     fn rebuild_report_inner(&mut self, analyses_changed: bool) {
-        let file1 = self.file1_path.display().to_string();
-        let file2 = self.file2_path.display().to_string();
-        self.report = build_diff_report(&DiffInput {
-            file1: &file1,
-            file2: &file2,
-            p1: &self.problem1,
-            p2: &self.problem2,
-            line_map1: &self.line_map1,
-            line_map2: &self.line_map2,
-            analysis1: self.report.analysis1.clone(),
-            analysis2: self.report.analysis2.clone(),
-            options: self.diff_options.clone(),
-        });
+        match self.mode {
+            AppMode::Diff => {
+                let file1 = self.file1_path.display().to_string();
+                let file2 = self.file2_path.display().to_string();
+                self.report = build_diff_report(&DiffInput {
+                    file1: &file1,
+                    file2: &file2,
+                    p1: &self.problem1,
+                    p2: &self.problem2,
+                    line_map1: &self.line_map1,
+                    line_map2: &self.line_map2,
+                    analysis1: self.report.analysis1.clone(),
+                    analysis2: self.report.analysis2.clone(),
+                    options: self.diff_options.clone(),
+                });
+            }
+            AppMode::Inspect => {
+                let file = self.file1_path.display().to_string();
+                self.report =
+                    crate::inspect_model::build_inspect_report(&file, &self.problem1, &self.line_map1, self.report.analysis1.clone());
+            }
+        }
 
         // Report-derived caches: search haystack + name buffer.
         let (haystack, names) = build_haystack(&self.report);
@@ -503,7 +600,7 @@ impl App {
         // Numerics lines depend only on the analyses, which change on watch
         // reloads but not on tolerance changes -- skip the rebuild otherwise.
         if analyses_changed {
-            self.numerics_lines = crate::widgets::numerics::build_numerics_lines(&self.report);
+            self.numerics_lines = build_mode_numerics_lines(self.mode, &self.report, &self.problem1);
         }
 
         // Filtered indices, cached sidebar lines, and coefficient row cache.
@@ -592,10 +689,15 @@ impl App {
         let filter = self.filter;
         let ignore_order = self.ignore_order;
         let sort = self.sort_mode;
+        let badges = self.mode.shows_diff_badges();
         match section {
-            Section::Variables => self.section_states[index].recompute(&self.report.variables.entries, filter, ignore_order, sort),
-            Section::Constraints => self.section_states[index].recompute(&self.report.constraints.entries, filter, ignore_order, sort),
-            Section::Objectives => self.section_states[index].recompute(&self.report.objectives.entries, filter, ignore_order, sort),
+            Section::Variables => self.section_states[index].recompute(&self.report.variables.entries, filter, ignore_order, sort, badges),
+            Section::Constraints => {
+                self.section_states[index].recompute(&self.report.constraints.entries, filter, ignore_order, sort, badges);
+            }
+            Section::Objectives => {
+                self.section_states[index].recompute(&self.report.objectives.entries, filter, ignore_order, sort, badges);
+            }
             Section::Summary | Section::Numerics => unreachable!("static sections have no list_index"),
         }
     }
@@ -813,7 +915,11 @@ impl App {
         self.set_yank_flash(&format!("Yanked detail: {label}"), &text);
     }
 
-    /// Export the full diff report as a CSV file in the current working directory.
+    /// Export to CSV in the current working directory.
+    ///
+    /// Diff mode writes the single `lp_diff_report_<timestamp>.csv`; inspect mode
+    /// writes the model itself via the core crate's `to_csv`
+    /// (`objectives.csv`, `constraints.csv`, `variables.csv`).
     pub fn export_csv(&mut self) {
         let dir = match std::env::current_dir() {
             Ok(d) => d,
@@ -823,16 +929,21 @@ impl App {
                 return;
             }
         };
-        match crate::export::write_diff_csv(&self.report, &dir) {
-            Ok(filename) => {
-                self.yank.message = format!("Wrote {filename}");
-                self.yank.flash = Some(Instant::now());
+        let result: Result<String, String> = match self.mode {
+            AppMode::Diff => {
+                crate::export::write_diff_csv(&self.report, &dir).map(|filename| format!("Wrote {filename}")).map_err(|e| e.to_string())
             }
-            Err(e) => {
-                self.yank.message = format!("CSV export failed: {e}");
-                self.yank.flash = Some(Instant::now());
-            }
+            AppMode::Inspect => self
+                .problem1
+                .to_csv(&dir)
+                .map(|()| "Wrote objectives.csv, constraints.csv, variables.csv".to_owned())
+                .map_err(|e| e.to_string()),
+        };
+        match result {
+            Ok(message) => self.yank.message = message,
+            Err(e) => self.yank.message = format!("CSV export failed: {e}"),
         }
+        self.yank.flash = Some(Instant::now());
     }
 
     /// Return the name of an entry given section and entry index.

--- a/tui/src/cli_output.rs
+++ b/tui/src/cli_output.rs
@@ -2,7 +2,13 @@
 //!
 //! Prints a structured text report to stdout and exits without launching the TUI.
 
+use lp_parser_rs::analysis::ProblemAnalysis;
+use lp_parser_rs::problem::LpProblem;
+
 use crate::diff_model::LpDiffReport;
+
+/// Maximum number of analysis issues listed in the inspect `--summary` output.
+const MAX_SUMMARY_ISSUES: usize = 20;
 
 /// Print a structured summary of the diff report to stdout.
 pub fn print_summary(report: &LpDiffReport) {
@@ -24,4 +30,34 @@ pub fn print_summary(report: &LpDiffReport) {
     println!();
     println!("Renamed: {} (counted once, excluded from added/removed)", summary.aggregate_counts().renamed);
     println!("Total: {} changes", summary.total_changes());
+}
+
+/// Print a structured single-file inspect summary to stdout: model counts and
+/// the top structural-analysis issues.
+pub fn print_inspect_summary(file: &str, problem: &LpProblem, analysis: &ProblemAnalysis) {
+    println!("LP Inspect: {file}");
+    if let Some(name) = problem.name() {
+        println!("Name:  {name}");
+    }
+    println!("Sense: {}", problem.sense);
+    println!();
+
+    println!("Variables:    {}", problem.variable_count());
+    println!("Constraints:  {}", problem.constraint_count());
+    println!("Objectives:   {}", problem.objective_count());
+    println!("Non-zeros:    {}", analysis.summary.total_nonzeros);
+    println!("Density:      {:.4}%", analysis.summary.density * 100.0);
+    println!();
+
+    if analysis.issues.is_empty() {
+        println!("Issues: none");
+        return;
+    }
+    println!("Issues: {}", analysis.issues.len());
+    for issue in analysis.issues.iter().take(MAX_SUMMARY_ISSUES) {
+        println!("  [{}] {}", issue.severity, issue.message);
+    }
+    if analysis.issues.len() > MAX_SUMMARY_ISSUES {
+        println!("  ... ({} more)", analysis.issues.len() - MAX_SUMMARY_ISSUES);
+    }
 }

--- a/tui/src/detail_text.rs
+++ b/tui/src/detail_text.rs
@@ -14,7 +14,7 @@ use crate::diff_model::{
 use crate::solver::{SolveDiffResult, SolveResult};
 use crate::state::{Section, Side};
 use crate::widgets::detail::{fmt_bound, variable_bounds};
-use crate::widgets::rule_str;
+use crate::widgets::{rule_str, short_filename};
 
 /// Writing to a `String` via `fmt::Write` is infallible. This macro replaces
 /// `let _ = writeln!(...)` with an asserting version that satisfies Tiger Style.
@@ -435,11 +435,6 @@ fn write_issues_plain(out: &mut String, report: &crate::diff_model::LpDiffReport
     }
 }
 
-/// Extract the filename from a path string for compact display.
-fn short_filename(path: &str) -> String {
-    std::path::Path::new(path).file_name().map_or_else(|| path.to_string(), |f| f.to_string_lossy().into_owned())
-}
-
 /// Write type/bounds lines for a single-side variable (added or removed).
 fn write_variable_type_info(out: &mut String, variable_type: &lp_parser_rs::model::VariableType) {
     let label = std::str::from_utf8(variable_type.as_ref()).unwrap_or("?");
@@ -612,23 +607,11 @@ const VAL_WIDTH: usize = 12;
 ///
 /// Avoids per-row `map_or_else` / `format!` heap allocations by writing into a
 /// caller-owned `String` buffer that is cleared before each use.
-fn fmt_opt_f64_precise(buf: &mut String, value: Option<f64>) -> &str {
+fn fmt_opt_f64(buf: &mut String, value: Option<f64>, precision: usize) -> &str {
     buf.clear();
     match value {
         Some(v) => {
-            write!(buf, "{v:.6}").expect("writing to String is infallible");
-            buf.as_str()
-        }
-        None => "\u{2014}",
-    }
-}
-
-/// Like [`fmt_opt_f64_precise`] but with 4 decimal places, for constraint tables.
-fn fmt_opt_f64_short(buf: &mut String, value: Option<f64>) -> &str {
-    buf.clear();
-    match value {
-        Some(v) => {
-            write!(buf, "{v:.4}").expect("writing to String is infallible");
+            write!(buf, "{v:.precision$}").expect("writing to String is infallible");
             buf.as_str()
         }
         None => "\u{2014}",
@@ -812,10 +795,10 @@ fn write_diff_variables(text: &mut String, diff: &SolveDiffResult) {
     let mut delta_buf = String::with_capacity(24);
     for row in &diff.variable_diff {
         let name = row.name(&diff.result1, &diff.result2);
-        let v1 = fmt_opt_f64_precise(&mut buf1, row.val1);
-        let v2 = fmt_opt_f64_precise(&mut buf2, row.val2);
-        let rc1 = fmt_opt_f64_precise(&mut buf3, row.reduced_cost1);
-        let rc2 = fmt_opt_f64_precise(&mut buf4, row.reduced_cost2);
+        let v1 = fmt_opt_f64(&mut buf1, row.val1, 6);
+        let v2 = fmt_opt_f64(&mut buf2, row.val2, 6);
+        let rc1 = fmt_opt_f64(&mut buf3, row.reduced_cost1, 6);
+        let rc2 = fmt_opt_f64(&mut buf4, row.reduced_cost2, 6);
         delta_buf.clear();
         let delta: &str = match (row.val1, row.val2) {
             (None, Some(_)) => "(added)",
@@ -848,10 +831,10 @@ fn write_diff_constraints(text: &mut String, diff: &SolveDiffResult) {
     let mut buf4 = String::with_capacity(16);
     for row in &diff.constraint_diff {
         let name = row.name(&diff.result1, &diff.result2);
-        let a1 = fmt_opt_f64_short(&mut buf1, row.activity1);
-        let a2 = fmt_opt_f64_short(&mut buf2, row.activity2);
-        let s1 = fmt_opt_f64_short(&mut buf3, row.shadow_price1);
-        let s2 = fmt_opt_f64_short(&mut buf4, row.shadow_price2);
+        let a1 = fmt_opt_f64(&mut buf1, row.activity1, 4);
+        let a2 = fmt_opt_f64(&mut buf2, row.activity2, 4);
+        let s1 = fmt_opt_f64(&mut buf3, row.shadow_price1, 4);
+        let s2 = fmt_opt_f64(&mut buf4, row.shadow_price2, 4);
         let marker = if row.changed { " *" } else { "" };
         w!(text, "  {:<22} {:>13} {:>13} {:>13} {:>13}{marker}", name, a1, a2, s1, s2);
     }

--- a/tui/src/detail_text.rs
+++ b/tui/src/detail_text.rs
@@ -12,7 +12,7 @@ use crate::diff_model::{
     ResolvedConstraint, VariableDiffEntry,
 };
 use crate::solver::{SolveDiffResult, SolveResult};
-use crate::state::{Section, Side};
+use crate::state::{AppMode, Section, Side};
 use crate::widgets::detail::{fmt_bound, variable_bounds};
 use crate::widgets::{rule_str, short_filename};
 
@@ -30,6 +30,9 @@ macro_rules! w {
 /// Render the currently selected detail panel as plain text.
 /// Returns `None` if no entry is selected (except for Summary, which has no entry).
 pub fn render_detail_plain(app: &App) -> Option<String> {
+    if app.mode == AppMode::Inspect {
+        return render_inspect_detail_plain(app);
+    }
     match app.active_section {
         Section::Summary => Some(render_summary_plain(app)),
         Section::Numerics => Some(render_numerics_plain(app)),
@@ -52,6 +55,137 @@ pub fn render_detail_plain(app: &App) -> Option<String> {
                 Section::Summary | Section::Numerics => unreachable!("handled above"),
             }
         }
+    }
+}
+
+/// Render the selected inspect (single-file) detail as neutral plain text.
+fn render_inspect_detail_plain(app: &App) -> Option<String> {
+    let interner = &app.report.interner;
+    match app.active_section {
+        Section::Summary => Some(render_inspect_summary_plain(app)),
+        Section::Numerics => Some(render_inspect_numerics_plain(app)),
+        Section::Variables => Some(render_inspect_variable_plain(app.report.variables.entries.get(app.selected_entry_index()?)?)),
+        Section::Constraints => {
+            Some(render_inspect_constraint_plain(app.report.constraints.entries.get(app.selected_entry_index()?)?, interner))
+        }
+        Section::Objectives => {
+            Some(render_inspect_objective_plain(app.report.objectives.entries.get(app.selected_entry_index()?)?, interner))
+        }
+    }
+}
+
+/// Neutral plain text for an inspect variable entry.
+fn render_inspect_variable_plain(entry: &VariableDiffEntry) -> String {
+    let mut out = String::new();
+    w!(out, "Variable: {}", entry.name);
+    w!(out, "{}", rule_str(38));
+    if let Some(variable_type) = entry.new_type.as_ref() {
+        write_variable_type_info(&mut out, variable_type);
+    }
+    out
+}
+
+/// Neutral plain text for an inspect constraint entry (operator/RHS/coeffs or SOS).
+fn render_inspect_constraint_plain(entry: &ConstraintDiffEntry, interner: &NameInterner) -> String {
+    let mut out = String::new();
+    w!(out, "Constraint: {}", entry.name);
+    w!(out, "{}", rule_str(38));
+    if let Some(line) = entry.line_file2.or(entry.line_file1) {
+        w!(out, "  Location: L{line}");
+    }
+    match &entry.detail {
+        ConstraintDiffDetail::AddedOrRemoved(ResolvedConstraint::Standard { coefficients, operator, rhs }) => {
+            if coefficients.is_empty() {
+                w!(out, "  Operator: {operator}");
+                w!(out, "  RHS:      {rhs}");
+            } else {
+                write_lp_expression(&mut out, &entry.name, coefficients, Some((*operator, *rhs)), interner);
+            }
+        }
+        ConstraintDiffDetail::AddedOrRemoved(ResolvedConstraint::Sos { sos_type, weights }) => {
+            w!(out, "  SOS Type: {sos_type}");
+            w!(out, "  Weights:");
+            for weight in weights {
+                w!(out, "    {:<20}{}", interner.resolve(weight.name), weight.value);
+            }
+        }
+        _ => w!(out, "  (unavailable)"),
+    }
+    out
+}
+
+/// Neutral plain text for an inspect objective entry (coefficients).
+fn render_inspect_objective_plain(entry: &ObjectiveDiffEntry, interner: &NameInterner) -> String {
+    let mut out = String::new();
+    w!(out, "Objective: {}", entry.name);
+    w!(out, "{}", rule_str(38));
+    if entry.new_coefficients.is_empty() {
+        w!(out, "  (no coefficients)");
+    } else {
+        write_lp_expression(&mut out, &entry.name, &entry.new_coefficients, None, interner);
+    }
+    out
+}
+
+/// Neutral single-file plain text for the inspect Summary panel.
+fn render_inspect_summary_plain(app: &App) -> String {
+    let problem = &app.problem1;
+    let analysis = &app.report.analysis1;
+    let counts = &app.cached_summary;
+    let mut out = String::with_capacity(512);
+
+    w!(out, "  {}", app.report.file1);
+    w!(out, "  Name:   {}", problem.name().unwrap_or("(unnamed)"));
+    w!(out, "  Sense:  {}", problem.sense);
+    w!(out);
+    w!(out, "  Variables:    {}", counts.variables.total());
+    w!(out, "  Constraints:  {}", counts.constraints.total());
+    w!(out, "  Objectives:   {}", counts.objectives.total());
+    w!(out, "  Non-zeros:    {}", analysis.summary.total_nonzeros);
+    w!(out, "  Density:      {:.4}%", analysis.summary.density * 100.0);
+    w!(out);
+    write_issues_single(&mut out, &analysis.issues);
+    out
+}
+
+/// Neutral single-file plain text for the inspect Numerics panel.
+fn render_inspect_numerics_plain(app: &App) -> String {
+    use crate::widgets::numerics::{count_by_severity, format_range, format_ratio, range_ratio};
+    let analysis = &app.report.analysis1;
+    let mut out = String::with_capacity(512);
+
+    w!(out, "  {}", app.report.file1);
+    w!(out);
+    w!(out, "  Problem Size");
+    w!(out, "  Variables:    {}", analysis.summary.variable_count);
+    w!(out, "  Constraints:  {}", analysis.summary.constraint_count);
+    w!(out, "  Non-zeros:    {}", analysis.summary.total_nonzeros);
+    w!(out, "  Density:      {:.4}%", analysis.summary.density * 100.0);
+    w!(out);
+    w!(out, "  Coefficient Ranges (|value|)");
+    for (label, range) in [
+        ("Objective", &analysis.coefficients.objective_coeff_range),
+        ("Matrix", &analysis.coefficients.constraint_coeff_range),
+        ("RHS", &analysis.constraints.rhs_range),
+    ] {
+        w!(out, "  {label:<12}{:>20}  ratio {}", format_range(range), format_ratio(range_ratio(range)));
+    }
+    w!(out, "  {:<12}{:>20}", "Overall ratio", format_ratio(Some(analysis.coefficients.coefficient_ratio)));
+    w!(out);
+    let (errors, warnings, infos) = count_by_severity(&analysis.issues);
+    w!(out, "  Issues: {errors} error(s), {warnings} warning(s), {infos} info");
+    write_issues_single(&mut out, &analysis.issues);
+    out
+}
+
+/// Write a single-file issues list (used by the inspect plain renderers).
+fn write_issues_single(out: &mut String, issues: &[lp_parser_rs::analysis::AnalysisIssue]) {
+    if issues.is_empty() {
+        w!(out, "  No issues detected");
+        return;
+    }
+    for issue in issues {
+        w!(out, "  [{:<7}] {}", issue.severity, issue.message);
     }
 }
 

--- a/tui/src/diff_model.rs
+++ b/tui/src/diff_model.rs
@@ -7,11 +7,14 @@ use std::collections::HashMap;
 use std::fmt;
 
 use lp_parser_rs::analysis::ProblemAnalysis;
+use lp_parser_rs::diff::DiffTol;
 use lp_parser_rs::interner::{NameId, NameInterner};
 use lp_parser_rs::model::{ComparisonOp, Constraint, SOSType, Sense, VariableType};
 use lp_parser_rs::problem::LpProblem;
 
-// Epsilon used for floating-point coefficient value comparison.
+// Epsilon used for floating-point coefficient value comparison. The TUI floors
+// the absolute tolerance at this value so ordinary float noise is suppressed
+// even when no tolerance is supplied — a presentation choice the CLI does not make.
 const COEFF_EPSILON: f64 = 1e-10;
 
 /// Preset tolerance values cycled by the live `t` / `T` keys in the TUI.
@@ -81,18 +84,15 @@ impl DiffOptions {
 
     /// Decide whether two floats should be treated as different under the configured tolerances.
     ///
-    /// Always floors the absolute tolerance at `COEFF_EPSILON` so that ordinary float noise
-    /// (e.g. `1.0` vs `1.0 + 1e-15`) is still suppressed when no tolerance is supplied.
+    /// Delegates to the core crate's [`DiffTol`] so both front-ends share one definition of
+    /// "numerically different". The absolute tolerance is floored at `COEFF_EPSILON` first,
+    /// so ordinary float noise (e.g. `1.0` vs `1.0 + 1e-15`) is still suppressed when no
+    /// tolerance is supplied — the CLI, which never floors, keeps its own exact semantics.
     #[must_use]
     pub fn numeric_differs(&self, a: f64, b: f64) -> bool {
         debug_assert!(self.abs_tol.is_finite() && self.abs_tol >= 0.0, "abs_tol must be finite and non-negative");
         debug_assert!(self.rel_tol.is_finite() && self.rel_tol >= 0.0, "rel_tol must be finite and non-negative");
-        let diff = (a - b).abs();
-        let abs_gate = self.abs_tol.max(COEFF_EPSILON);
-        if diff <= abs_gate {
-            return false;
-        }
-        diff > self.rel_tol * a.abs().max(b.abs())
+        DiffTol { abs: self.abs_tol.max(COEFF_EPSILON), rel: self.rel_tol }.differ(a, b)
     }
 }
 

--- a/tui/src/diff_model.rs
+++ b/tui/src/diff_model.rs
@@ -578,18 +578,15 @@ pub fn sort_indices_by_delta<T: DiffEntry>(entries: &[T], indices: &mut [usize],
 
 /// Diff two coefficient lists using sorted merge-join and return only the changed entries.
 ///
-/// Both slices are sorted by name (resolved via `interner`) before merging. Numeric
-/// comparison respects `opts.abs_tol` / `opts.rel_tol` (with a `COEFF_EPSILON` floor).
-fn diff_coefficients(
-    old: &[ResolvedCoefficient],
-    new: &[ResolvedCoefficient],
-    interner: &NameInterner,
-    opts: &DiffOptions,
-) -> Vec<CoefficientChange> {
+/// Both slices are sorted by `NameId` before merging; since both share the report's
+/// `interner`, any consistent order gives a valid merge-join without resolving to
+/// strings. Numeric comparison respects `opts.abs_tol` / `opts.rel_tol` (with a
+/// `COEFF_EPSILON` floor).
+fn diff_coefficients(old: &[ResolvedCoefficient], new: &[ResolvedCoefficient], opts: &DiffOptions) -> Vec<CoefficientChange> {
     let mut old_sorted: Vec<(NameId, f64)> = old.iter().map(|c| (c.name, c.value)).collect();
     let mut new_sorted: Vec<(NameId, f64)> = new.iter().map(|c| (c.name, c.value)).collect();
-    old_sorted.sort_unstable_by(|a, b| interner.resolve(a.0).cmp(interner.resolve(b.0)));
-    new_sorted.sort_unstable_by(|a, b| interner.resolve(a.0).cmp(interner.resolve(b.0)));
+    old_sorted.sort_unstable_by_key(|a| a.0);
+    new_sorted.sort_unstable_by_key(|a| a.0);
 
     let mut changes = Vec::new();
     let mut i = 0;
@@ -600,7 +597,7 @@ fn diff_coefficients(
         debug_assert!(j <= new_sorted.len(), "new index out of bounds");
 
         let cmp = match (old_sorted.get(i), new_sorted.get(j)) {
-            (Some((n1, _)), Some((n2, _))) => interner.resolve(*n1).cmp(interner.resolve(*n2)),
+            (Some((n1, _)), Some((n2, _))) => n1.cmp(n2),
             (Some(_), None) => std::cmp::Ordering::Less,
             (None, Some(_)) => std::cmp::Ordering::Greater,
             (None, None) => break,
@@ -754,11 +751,11 @@ fn diff_standard_constraints(
     new_coefficients: &[ResolvedCoefficient],
     new_operator: ComparisonOp,
     new_rhs: f64,
-    interner: &NameInterner,
+    _interner: &NameInterner,
     order_changed: bool,
     opts: &DiffOptions,
 ) -> Option<ConstraintDiffDetail> {
-    let coeff_changes = diff_coefficients(old_coefficients, new_coefficients, interner, opts);
+    let coeff_changes = diff_coefficients(old_coefficients, new_coefficients, opts);
     let operator_change = if old_operator == new_operator { None } else { Some((old_operator, new_operator)) };
     let rhs_change = if opts.numeric_differs(old_rhs, new_rhs) { Some((old_rhs, new_rhs)) } else { None };
 
@@ -785,11 +782,11 @@ fn diff_sos_constraints(
     old_weights: &[ResolvedCoefficient],
     new_type: SOSType,
     new_weights: &[ResolvedCoefficient],
-    interner: &NameInterner,
+    _interner: &NameInterner,
     order_changed: bool,
     opts: &DiffOptions,
 ) -> Option<ConstraintDiffDetail> {
-    let weight_changes = diff_coefficients(old_weights, new_weights, interner, opts);
+    let weight_changes = diff_coefficients(old_weights, new_weights, opts);
     let type_change = if old_type == new_type { None } else { Some((old_type, new_type)) };
 
     if weight_changes.is_empty() && type_change.is_none() && !order_changed {
@@ -1199,7 +1196,7 @@ fn diff_objectives(p1: &LpProblem, p2: &LpProblem, interner: &mut NameInterner, 
                 let reordered = coefficients_reordered(p1, &o1_val.coefficients, p2, &o2_val.coefficients, opts);
                 let old_resolved = resolve_coefficients(p1, &o1_val.coefficients, interner, opts);
                 let new_resolved = resolve_coefficients(p2, &o2_val.coefficients, interner, opts);
-                let coeff_changes = diff_coefficients(&old_resolved, &new_resolved, interner, opts);
+                let coeff_changes = diff_coefficients(&old_resolved, &new_resolved, opts);
                 if coeff_changes.is_empty() && !reordered {
                     counts.unchanged += 1;
                 } else {

--- a/tui/src/diff_model.rs
+++ b/tui/src/diff_model.rs
@@ -2,6 +2,7 @@
 //!
 //! This module is pure data types and logic — no ratatui dependency.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -67,15 +68,15 @@ impl DiffOptions {
     /// Rewrite a name through the rename rules in order. Returns the original string
     /// unchanged when no rules are configured (avoiding an allocation in the hot path).
     #[must_use]
-    pub fn rewrite(&self, name: &str) -> String {
+    pub fn rewrite<'a>(&self, name: &'a str) -> Cow<'a, str> {
         if self.rename_rules.is_empty() {
-            return name.to_string();
+            return Cow::Borrowed(name);
         }
         let mut s = name.to_string();
         for (re, rep) in &self.rename_rules {
             s = re.replace_all(&s, rep.as_str()).into_owned();
         }
-        s
+        Cow::Owned(s)
     }
 
     /// Decide whether two floats should be treated as different under the configured tolerances.
@@ -154,8 +155,8 @@ fn coefficients_reordered(
     if positional_match {
         return false;
     }
-    let mut n1: Vec<String> = c1.iter().map(|c| opts.rewrite(p1.resolve(c.name))).collect();
-    let mut n2: Vec<String> = c2.iter().map(|c| opts.rewrite(p2.resolve(c.name))).collect();
+    let mut n1: Vec<Cow<'_, str>> = c1.iter().map(|c| opts.rewrite(p1.resolve(c.name))).collect();
+    let mut n2: Vec<Cow<'_, str>> = c2.iter().map(|c| opts.rewrite(p2.resolve(c.name))).collect();
     n1.sort_unstable();
     n2.sort_unstable();
     n1 == n2
@@ -653,7 +654,7 @@ fn constraint_summary(problem: &LpProblem, constraint: &Constraint) -> String {
 /// Build a sorted vec of (`canonical_name`, &Variable) pairs.
 /// `canonical_name` is the original name with `opts.rename_rules` applied.
 fn build_sorted_vars<'a>(problem: &'a LpProblem, opts: &DiffOptions) -> Vec<(String, &'a lp_parser_rs::model::Variable)> {
-    let mut pairs: Vec<_> = problem.variables.iter().map(|(id, var)| (opts.rewrite(problem.resolve(*id)), var)).collect();
+    let mut pairs: Vec<_> = problem.variables.iter().map(|(id, var)| (opts.rewrite(problem.resolve(*id)).into_owned(), var)).collect();
     pairs.sort_unstable_by(|a, b| a.0.cmp(&b.0));
     pairs
 }
@@ -663,14 +664,14 @@ fn build_sorted_vars<'a>(problem: &'a LpProblem, opts: &DiffOptions) -> Vec<(Str
 /// Preserves the original per-file `NameId` for line-map lookups while using the
 /// rewritten (canonical) name for sort and merge-join.
 fn build_sorted_constraints<'a>(problem: &'a LpProblem, opts: &DiffOptions) -> Vec<(NameId, String, &'a Constraint)> {
-    let mut triples: Vec<_> = problem.constraints.iter().map(|(id, c)| (*id, opts.rewrite(problem.resolve(*id)), c)).collect();
+    let mut triples: Vec<_> = problem.constraints.iter().map(|(id, c)| (*id, opts.rewrite(problem.resolve(*id)).into_owned(), c)).collect();
     triples.sort_unstable_by(|a, b| a.1.cmp(&b.1));
     triples
 }
 
 /// Build a sorted vec of (`canonical_name`, &Objective) pairs.
 fn build_sorted_objectives<'a>(problem: &'a LpProblem, opts: &DiffOptions) -> Vec<(String, &'a lp_parser_rs::model::Objective)> {
-    let mut pairs: Vec<_> = problem.objectives.iter().map(|(id, o)| (opts.rewrite(problem.resolve(*id)), o)).collect();
+    let mut pairs: Vec<_> = problem.objectives.iter().map(|(id, o)| (opts.rewrite(problem.resolve(*id)).into_owned(), o)).collect();
     pairs.sort_unstable_by(|a, b| a.0.cmp(&b.0));
     pairs
 }

--- a/tui/src/export.rs
+++ b/tui/src/export.rs
@@ -43,8 +43,8 @@ pub fn write_diff_csv(report: &LpDiffReport, dir: &Path) -> Result<String, Box<d
                 }
             }
             DiffKind::Modified => {
-                let old_label = entry.old_type.as_ref().map_or("?", |t| type_label(t));
-                let new_label = entry.new_type.as_ref().map_or("?", |t| type_label(t));
+                let old_label = entry.old_type.as_ref().map_or_else(|| "?".to_owned(), ToString::to_string);
+                let new_label = entry.new_type.as_ref().map_or_else(|| "?".to_owned(), ToString::to_string);
                 write!(detail_buf, "{old_label} -> {new_label}").expect("writing to String cannot fail");
             }
             DiffKind::Renamed => {
@@ -128,21 +128,4 @@ pub fn write_diff_csv(report: &LpDiffReport, dir: &Path) -> Result<String, Box<d
 
     wtr.flush()?;
     Ok(filename)
-}
-
-/// Return a short label for a `VariableType`, borrowing the Display output
-/// without allocating for the common cases.
-const fn type_label(t: &lp_parser_rs::model::VariableType) -> &'static str {
-    use lp_parser_rs::model::VariableType;
-    match t {
-        VariableType::Free => "Free",
-        VariableType::General => "General",
-        VariableType::Binary => "Binary",
-        VariableType::Integer => "Integer",
-        VariableType::SemiContinuous => "Semi-Continuous",
-        VariableType::SOS => "SOS",
-        VariableType::LowerBound(_) => "LowerBound",
-        VariableType::UpperBound(_) => "UpperBound",
-        VariableType::DoubleBound(_, _) => "DoubleBound",
-    }
 }

--- a/tui/src/input.rs
+++ b/tui/src/input.rs
@@ -6,7 +6,9 @@ use lp_parser_rs::problem::LpProblem;
 
 use crate::app::App;
 use crate::detail_text::{format_solve_diff_result, format_solve_result};
-use crate::state::{DiagnosisState, DiffFilter, Focus, PaletteCommand, PendingYank, Section, Side, SolveState, SolveTab, SolveViewState};
+use crate::state::{
+    AppMode, DiagnosisState, DiffFilter, Focus, PaletteCommand, PendingYank, Section, Side, SolveState, SolveTab, SolveViewState,
+};
 
 impl App {
     pub fn handle_key(&mut self, key: KeyEvent) {
@@ -66,17 +68,25 @@ impl App {
     }
 
     /// Recompute the palette's filtered command list from the current query.
+    ///
+    /// In inspect mode the diff-only commands are excluded entirely so the
+    /// palette only offers actions that actually do something.
     fn recompute_palette(&mut self) {
         self.palette.selected = 0;
         self.palette.filtered.clear();
+        let inspect = self.mode == AppMode::Inspect;
+        let available = |index: usize| !inspect || PaletteCommand::ALL[index].available_in_inspect();
         if self.palette.query.is_empty() {
-            self.palette.filtered.extend(0..PaletteCommand::ALL.len());
+            self.palette.filtered.extend((0..PaletteCommand::ALL.len()).filter(|&i| available(i)));
             return;
         }
         let labels: Vec<String> = PaletteCommand::ALL.iter().map(|c| c.label().to_owned()).collect();
         let config = frizbee::Config { sort: true, ..Default::default() };
         for matched in frizbee::match_list_indices(&self.palette.query, &labels, &config) {
-            self.palette.filtered.push(matched.index as usize);
+            let index = matched.index as usize;
+            if available(index) {
+                self.palette.filtered.push(index);
+            }
         }
     }
 
@@ -131,7 +141,7 @@ impl App {
             PaletteCommand::CycleRelTol => self.cycle_rel_tol(),
             PaletteCommand::CycleAbsTol => self.cycle_abs_tol(),
             PaletteCommand::OpenSearch => self.open_search_popup(),
-            PaletteCommand::Solve => self.solver.state = SolveState::Picking,
+            PaletteCommand::Solve => self.start_solve(),
             PaletteCommand::ExportCsv => self.export_csv(),
             PaletteCommand::YankName => self.yank_name(),
             PaletteCommand::YankOld => self.yank_side(Side::Old),
@@ -187,6 +197,11 @@ impl App {
         if self.pending_yank == PendingYank::WaitingForTarget {
             self.pending_yank = PendingYank::None;
             match key.code {
+                // Old/new side yanks are per-file (file 1 / file 2) — diff-only.
+                KeyCode::Char('o' | 'n') if self.mode == AppMode::Inspect => {
+                    self.flash_diff_only();
+                    return;
+                }
                 KeyCode::Char('o') => {
                     self.yank_side(Side::Old);
                     return;
@@ -236,19 +251,19 @@ impl App {
             KeyCode::Char('l') => self.focus_detail(),
             KeyCode::Char('h') => self.focus_sidebar(),
 
-            // Filter shortcuts.
-            KeyCode::Char('a') => self.set_filter(DiffFilter::All),
-            KeyCode::Char('+') => self.set_filter(DiffFilter::Added),
-            KeyCode::Char('-') => self.set_filter(DiffFilter::Removed),
-            KeyCode::Char('m') => self.set_filter(DiffFilter::Modified),
-            KeyCode::Char('=') => self.set_filter(DiffFilter::Renamed),
+            // Filter shortcuts (diff-only: no-op with a hint in inspect mode).
+            KeyCode::Char('a') => self.filter_or_hint(DiffFilter::All),
+            KeyCode::Char('+') => self.filter_or_hint(DiffFilter::Added),
+            KeyCode::Char('-') => self.filter_or_hint(DiffFilter::Removed),
+            KeyCode::Char('m') => self.filter_or_hint(DiffFilter::Modified),
+            KeyCode::Char('=') => self.filter_or_hint(DiffFilter::Renamed),
 
-            // Cycle the sidebar sort mode (name → |Δ| → relΔ).
-            KeyCode::Char('s') => self.cycle_sort_mode(),
+            // Cycle the sidebar sort mode (delta modes are diff-only).
+            KeyCode::Char('s') => self.diff_only_or(Self::cycle_sort_mode),
 
-            // Live tolerance adjustment — rebuilds the diff in place.
-            KeyCode::Char('t') => self.cycle_rel_tol(),
-            KeyCode::Char('T') => self.cycle_abs_tol(),
+            // Live tolerance adjustment — rebuilds the diff in place (diff-only).
+            KeyCode::Char('t') => self.diff_only_or(Self::cycle_rel_tol),
+            KeyCode::Char('T') => self.diff_only_or(Self::cycle_abs_tol),
 
             KeyCode::Char('?') => {
                 self.show_help = !self.show_help;
@@ -259,22 +274,54 @@ impl App {
             KeyCode::Char('y') => self.pending_yank = PendingYank::WaitingForTarget,
             KeyCode::Char('Y') => self.yank_detail(),
 
-            // Open the solver file picker.
-            KeyCode::Char('S') => self.solver.state = SolveState::Picking,
+            // Solve: inspect solves the single file directly; diff opens the picker.
+            KeyCode::Char('S') => self.start_solve(),
 
-            // Export the diff report as CSV.
+            // Export CSV (works in both modes).
             KeyCode::Char('w') => self.export_csv(),
 
-            // Toggle raw text side-by-side diff view.
-            KeyCode::Char('r') => self.toggle_detail_view(),
+            // Toggle raw text side-by-side diff view (diff-only).
+            KeyCode::Char('r') => self.diff_only_or(Self::toggle_detail_view),
 
-            // Toggle hiding order-only coefficient changes.
-            KeyCode::Char('o') => self.toggle_ignore_order(),
+            // Toggle hiding order-only coefficient changes (diff-only).
+            KeyCode::Char('o') => self.diff_only_or(Self::toggle_ignore_order),
 
             // Open the search pop-up.
             KeyCode::Char('/') => self.open_search_popup(),
 
             _ => {}
+        }
+    }
+
+    /// Apply a kind filter in diff mode; in inspect mode filters are diff-only,
+    /// so this shows a brief hint instead.
+    fn filter_or_hint(&mut self, filter: DiffFilter) {
+        if self.mode == AppMode::Inspect {
+            self.flash_diff_only();
+        } else {
+            self.set_filter(filter);
+        }
+    }
+
+    /// Run a diff-only action, or show a brief hint when in inspect mode.
+    fn diff_only_or(&mut self, action: fn(&mut Self)) {
+        if self.mode == AppMode::Inspect {
+            self.flash_diff_only();
+        } else {
+            action(self);
+        }
+    }
+
+    /// Start a solve: inspect mode solves the single file directly; diff mode
+    /// opens the file picker (file 1 / file 2 / both).
+    pub(crate) fn start_solve(&mut self) {
+        match self.mode {
+            AppMode::Inspect => {
+                let problem = Arc::clone(&self.problem1);
+                let label = self.file1_path.display().to_string();
+                self.spawn_solver(problem, label);
+            }
+            AppMode::Diff => self.solver.state = SolveState::Picking,
         }
     }
 

--- a/tui/src/input.rs
+++ b/tui/src/input.rs
@@ -390,14 +390,7 @@ impl App {
             Focus::SectionSelector => {
                 let current = self.section_selector_state.selected().unwrap_or(0);
                 let new_index = (current + 1).min(Section::ALL.len() - 1);
-                let new_section = Section::from_index(new_index);
-                if self.active_section != new_section {
-                    self.set_active_section(new_section);
-                    self.invalidate_cache();
-                    self.ensure_active_section_cache();
-                    self.reset_name_list_selection();
-                    self.detail_scroll = 0;
-                }
+                self.select_section_via_selector(Section::from_index(new_index));
             }
             Focus::NameList => {
                 let len = self.name_list_len();
@@ -421,14 +414,7 @@ impl App {
             Focus::SectionSelector => {
                 let current = self.section_selector_state.selected().unwrap_or(0);
                 let new_index = current.saturating_sub(1);
-                let new_section = Section::from_index(new_index);
-                if self.active_section != new_section {
-                    self.set_active_section(new_section);
-                    self.invalidate_cache();
-                    self.ensure_active_section_cache();
-                    self.reset_name_list_selection();
-                    self.detail_scroll = 0;
-                }
+                self.select_section_via_selector(Section::from_index(new_index));
             }
             Focus::NameList => {
                 let len = self.name_list_len();
@@ -450,14 +436,7 @@ impl App {
     fn jump_to_top(&mut self) {
         match self.focus {
             Focus::SectionSelector => {
-                let new_section = Section::Summary;
-                if self.active_section != new_section {
-                    self.set_active_section(new_section);
-                    self.invalidate_cache();
-                    self.ensure_active_section_cache();
-                    self.reset_name_list_selection();
-                    self.detail_scroll = 0;
-                }
+                self.select_section_via_selector(Section::Summary);
             }
             Focus::NameList => {
                 let len = self.name_list_len();
@@ -475,14 +454,7 @@ impl App {
     fn jump_to_bottom(&mut self) {
         match self.focus {
             Focus::SectionSelector => {
-                let new_section = Section::Numerics;
-                if self.active_section != new_section {
-                    self.set_active_section(new_section);
-                    self.invalidate_cache();
-                    self.ensure_active_section_cache();
-                    self.detail_scroll = 0;
-                    self.reset_name_list_selection();
-                }
+                self.select_section_via_selector(Section::Numerics);
             }
             Focus::NameList => {
                 let len = self.name_list_len();
@@ -792,6 +764,18 @@ impl App {
     /// Switch the solve popup to a different tab, preserving per-tab scroll position.
     const fn switch_solve_tab(&mut self, tab: SolveTab) {
         self.solver.view.tab = tab;
+    }
+
+    /// Switch to `new_section` from the section selector, refreshing caches and
+    /// selection only when the section actually changes.
+    fn select_section_via_selector(&mut self, new_section: Section) {
+        if self.active_section != new_section {
+            self.set_active_section(new_section);
+            self.invalidate_cache();
+            self.ensure_active_section_cache();
+            self.reset_name_list_selection();
+            self.detail_scroll = 0;
+        }
     }
 
     pub(crate) fn set_section(&mut self, section: Section) {

--- a/tui/src/inspect_model.rs
+++ b/tui/src/inspect_model.rs
@@ -1,0 +1,114 @@
+//! Single-file inspect model.
+//!
+//! Inspect mode (`lp_diff model.lp`, one positional file) reuses the diff
+//! report machinery so navigation, search, and the detail panel work unchanged:
+//! the model's section lists are built by diffing the parsed problem against an
+//! empty problem, which yields exactly one `Added` entry per variable,
+//! constraint, and objective. The presentation layer keys off
+//! [`AppMode::Inspect`](crate::state::AppMode) to drop the diff badges/colours so
+//! the result reads as a plain single-model explorer, not a diff.
+
+use std::collections::HashMap;
+
+use lp_parser_rs::analysis::ProblemAnalysis;
+use lp_parser_rs::interner::NameId;
+use lp_parser_rs::problem::LpProblem;
+
+use crate::diff_model::{DiffInput, DiffOptions, LpDiffReport, build_diff_report};
+
+/// Build the inspect report for a single parsed problem.
+///
+/// The problem is diffed against an empty problem so every entry surfaces as
+/// `Added`; the diff kinds are ignored by the inspect presentation, which lists
+/// entries plainly. Both stored analyses are set to the single file's analysis
+/// so the Summary/Numerics inspect views render the file's own conditioning.
+///
+/// `line_map` is the constraint→line-number map for the file, threaded through
+/// so the detail panel can show source locations.
+#[must_use]
+pub fn build_inspect_report(file: &str, problem: &LpProblem, line_map: &HashMap<NameId, usize>, analysis: ProblemAnalysis) -> LpDiffReport {
+    debug_assert!(!file.is_empty(), "inspect file label must not be empty");
+
+    let empty = LpProblem::default();
+    let empty_line_map: HashMap<NameId, usize> = HashMap::new();
+
+    build_diff_report(&DiffInput {
+        // Both labels are the single file: nothing in the report ever reads as
+        // "vs file2", and any shared rendering falls back to the real filename.
+        file1: file,
+        file2: file,
+        // Empty base vs the real problem → every entry is Added.
+        p1: &empty,
+        p2: problem,
+        line_map1: &empty_line_map,
+        line_map2: line_map,
+        analysis1: analysis.clone(),
+        analysis2: analysis,
+        // Inspect never applies tolerances or rename rules — it is not a comparison.
+        options: DiffOptions::default(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use lp_parser_rs::model::VariableType;
+    use lp_parser_rs::problem::LpProblem;
+
+    use super::*;
+    use crate::diff_model::{ConstraintDiffDetail, DiffKind, ResolvedConstraint};
+
+    fn analyse(problem: &LpProblem) -> ProblemAnalysis {
+        problem.analyze()
+    }
+
+    #[test]
+    fn test_inspect_lists_all_variables_as_added() {
+        let problem =
+            LpProblem::parse("minimize\nobj: 2 x + 3 y\nsubject to\n c1: x + y <= 10\nbinary\n x\nend").expect("problem should parse");
+        let report = build_inspect_report("model.lp", &problem, &HashMap::new(), analyse(&problem));
+
+        // Every variable in the file appears exactly once, all as Added, no removals.
+        assert_eq!(report.variables.counts.removed, 0);
+        assert_eq!(report.variables.counts.modified, 0);
+        assert!(report.variables.entries.iter().all(|e| e.kind == DiffKind::Added));
+        assert!(report.variables.entries.iter().any(|e| e.name == "x"));
+        assert!(report.variables.entries.iter().any(|e| e.name == "y"));
+
+        let x = report.variables.entries.iter().find(|e| e.name == "x").expect("x present");
+        assert_eq!(x.new_type, Some(VariableType::Binary));
+        assert!(x.old_type.is_none(), "inspect entries never carry an old side");
+    }
+
+    #[test]
+    fn test_inspect_lists_constraints_and_objectives() {
+        let problem =
+            LpProblem::parse("minimize\nobj: x + y\nsubject to\n c1: x + 2 y <= 5\n c2: x >= 1\nend").expect("problem should parse");
+        let report = build_inspect_report("model.lp", &problem, &HashMap::new(), analyse(&problem));
+
+        let names: Vec<&str> = report.constraints.entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"c1"), "c1 listed");
+        assert!(names.contains(&"c2"), "c2 listed");
+        assert!(report.constraints.entries.iter().all(|e| e.kind == DiffKind::Added));
+
+        // A constraint's detail carries the full single-side data (operator/RHS/coeffs).
+        let c1 = report.constraints.entries.iter().find(|e| e.name == "c1").expect("c1 present");
+        let ConstraintDiffDetail::AddedOrRemoved(ResolvedConstraint::Standard { coefficients, rhs, .. }) = &c1.detail else {
+            panic!("expected an added standard constraint");
+        };
+        assert!((*rhs - 5.0).abs() < 1e-9, "rhs should be 5.0");
+        assert_eq!(coefficients.len(), 2, "x and y coefficients present");
+
+        assert!(report.objectives.entries.iter().any(|e| e.name == "obj"));
+        assert!(report.objectives.entries.iter().all(|e| e.kind == DiffKind::Added));
+    }
+
+    #[test]
+    fn test_inspect_problem_without_constraints_lists_none() {
+        // A model with an objective and one variable but no constraints.
+        let problem = LpProblem::parse("minimize\nobj: x\nsubject to\nend").expect("problem should parse");
+        let report = build_inspect_report("model.lp", &problem, &HashMap::new(), analyse(&problem));
+        assert!(report.constraints.entries.is_empty(), "no constraints in the model");
+        assert!(report.variables.entries.iter().any(|e| e.name == "x"), "x is listed");
+        assert!(report.objectives.entries.iter().any(|e| e.name == "obj"), "obj is listed");
+    }
+}

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -1,8 +1,10 @@
-//! `lp_diff` — interactive terminal viewer for diffing two LP or MPS files.
+//! `lp_diff` — LP/MPS model explorer and diff viewer.
 //!
-//! Parses both files, computes a structural diff (variables, constraints,
-//! objectives), and launches a TUI for exploring the changes. With `--summary`
-//! it prints a structured summary to stdout and exits without the TUI.
+//! With two files it parses both, computes a structural diff (variables,
+//! constraints, objectives), and launches a TUI for exploring the changes. With
+//! a single file it opens an inspect view: a single-model explorer over the same
+//! sections. With `--summary` it prints a structured summary to stdout and exits
+//! without the TUI.
 //!
 //! # Exit codes
 //!
@@ -19,6 +21,7 @@ mod diff_model;
 mod event;
 mod export;
 mod input;
+mod inspect_model;
 mod line_index;
 mod parse;
 mod search;
@@ -46,19 +49,21 @@ use crate::diff_model::{DiffInput, DiffOptions, build_diff_report};
 use crate::event::{Event, EventHandler};
 use crate::parse::parse_file;
 
-/// Interactive diff viewer for LP and MPS files
+/// LP/MPS model explorer and diff viewer
+///
+/// With one file it opens a single-model explorer; with two files it diffs them.
 #[derive(Parser)]
 #[command(name = "lp_diff", version, about)]
 struct Cli {
-    /// First file (base)
+    /// Model file to inspect, or the base file when comparing two
     file1: PathBuf,
-    /// Second file (compare against)
-    file2: PathBuf,
+    /// Optional second file: when given, the two files are compared (diff mode)
+    file2: Option<PathBuf>,
     /// Print a structured summary to stdout and exit without launching the TUI
     #[arg(long)]
     summary: bool,
 
-    /// Reload and re-diff automatically when either input file changes on disk
+    /// Reload automatically when an input file changes on disk
     #[arg(long)]
     watch: bool,
 
@@ -223,11 +228,10 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if !args.file1.exists() {
         return Err(format!("file not found: '{}'", args.file1.display()).into());
     }
-    if !args.file2.exists() {
-        return Err(format!("file not found: '{}'", args.file2.display()).into());
-    }
 
     // Validate + compile comparison options before parsing (fails fast on bad regex).
+    // These only affect diff mode, but validating unconditionally keeps the error
+    // messages consistent regardless of how many files were supplied.
     if !args.abs_tol.is_finite() || args.abs_tol < 0.0 {
         return Err(format!("--abs-tol must be a finite non-negative number, got {}", args.abs_tol).into());
     }
@@ -237,14 +241,27 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let rename_rules = build_rename_rules(&args.rename)?;
     let diff_options = DiffOptions { abs_tol: args.abs_tol, rel_tol: args.rel_tol, rename_rules };
 
-    // Parse both files in parallel using scoped threads
+    // One file → inspect (single-model explorer); two files → diff.
+    match args.file2.clone() {
+        Some(file2) => run_diff(&args, file2, diff_options),
+        None => run_inspect(&args),
+    }
+}
+
+/// Diff mode: parse both files, build the diff report, and launch (or summarise).
+fn run_diff(args: &Cli, file2: PathBuf, diff_options: DiffOptions) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if !file2.exists() {
+        return Err(format!("file not found: '{}'", file2.display()).into());
+    }
+
+    // Parse both files in parallel using scoped threads.
     let start = Instant::now();
     eprintln!("Parsing both files in parallel...");
     stderr().flush()?;
 
     let (result1, result2) = std::thread::scope(|s| {
         let h1 = s.spawn(|| parse_file(&args.file1));
-        let h2 = s.spawn(|| parse_file(&args.file2));
+        let h2 = s.spawn(|| parse_file(&file2));
         (h1.join(), h2.join())
     });
 
@@ -256,7 +273,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         args.file1.display(),
         owned1.variable_count(),
         owned1.constraint_count(),
-        args.file2.display(),
+        file2.display(),
         owned2.variable_count(),
         owned2.constraint_count(),
         start.elapsed().as_secs_f64(),
@@ -266,7 +283,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     eprint!("Computing diff... ");
     stderr().flush()?;
     let file1_str = args.file1.display().to_string();
-    let file2_str = args.file2.display().to_string();
+    let file2_str = file2.display().to_string();
     let report = build_diff_report(&DiffInput {
         file1: &file1_str,
         file2: &file2_str,
@@ -287,6 +304,50 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         return Ok(());
     }
 
+    // Wrap parsed problems in Arc for sharing with solver threads.
+    let problem1 = Arc::new(owned1);
+    let problem2 = Arc::new(owned2);
+    let raw_text1: Arc<str> = raw_text1.into();
+    let raw_text2: Arc<str> = raw_text2.into();
+    let app = App::new(report, args.file1.clone(), file2, problem1, problem2, raw_text1, raw_text2, diff_options, line_map1, line_map2);
+
+    launch_tui(app, args.watch)
+}
+
+/// Inspect mode: parse the single file, build the inspect model, and launch (or summarise).
+fn run_inspect(args: &Cli) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let start = Instant::now();
+    eprintln!("Parsing file...");
+    stderr().flush()?;
+
+    let (owned, analysis, line_map, raw_text) = parse_file(&args.file1)?;
+
+    eprintln!(
+        "Parsed {} ({} vars, {} cons) in {:.1}s",
+        args.file1.display(),
+        owned.variable_count(),
+        owned.constraint_count(),
+        start.elapsed().as_secs_f64(),
+    );
+
+    let file_str = args.file1.display().to_string();
+    let report = inspect_model::build_inspect_report(&file_str, &owned, &line_map, analysis);
+
+    // Non-interactive summary mode: print and exit.
+    if args.summary {
+        cli_output::print_inspect_summary(&file_str, &owned, &report.analysis1);
+        return Ok(());
+    }
+
+    let problem = Arc::new(owned);
+    let raw_text: Arc<str> = raw_text.into();
+    let app = App::new_inspect(report, args.file1.clone(), problem, raw_text, line_map);
+
+    launch_tui(app, args.watch)
+}
+
+/// Shared TUI lifecycle: set up the terminal, run the event loop, and restore.
+fn launch_tui(mut app: App, watch: bool) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     eprintln!("Launching viewer...");
 
     // Set up terminal — enable_raw_mode() must happen before EventHandler::new()
@@ -310,15 +371,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         original_hook(panic_info);
     }));
 
-    // Wrap parsed problems in Arc for sharing with solver threads.
-    let problem1 = Arc::new(owned1);
-    let problem2 = Arc::new(owned2);
-
-    // Create app and event handler
-    let raw_text1: Arc<str> = raw_text1.into();
-    let raw_text2: Arc<str> = raw_text2.into();
-    let mut app = App::new(report, args.file1, args.file2, problem1, problem2, raw_text1, raw_text2, diff_options, line_map1, line_map2);
-    if args.watch {
+    if watch {
         app.enable_watch();
     }
     let events = EventHandler::new(Duration::from_millis(50));

--- a/tui/src/solver.rs
+++ b/tui/src/solver.rs
@@ -537,6 +537,9 @@ fn extract_solution(
     }
 }
 
+/// Monotonic counter distinguishing concurrent solver-log temp files within one process.
+static SOLVE_LOG_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Convert an `LpProblem` to a `HiGHS` `RowProblem` and solve it.
 pub fn solve_problem(problem: &LpProblem) -> Result<SolveResult, String> {
     debug_assert!(!problem.variables.is_empty(), "cannot solve a problem with no variables");
@@ -545,9 +548,11 @@ pub fn solve_problem(problem: &LpProblem) -> Result<SolveResult, String> {
     let model = build_highs_model(problem);
     let build_time = build_start.elapsed();
 
-    // ponytail: pid-named temp file + explicit cleanup instead of the tempfile crate;
-    // one solve at a time per process, so no collision risk.
-    let log_path = std::env::temp_dir().join(format!("lp_diff_solver_{}.log", std::process::id()));
+    // ponytail: pid+sequence-named temp file + explicit cleanup instead of the
+    // tempfile crate. The sequence number keeps concurrent solves in one process
+    // ("Solve both" runs two solver threads) from clobbering each other's log.
+    let log_seq = SOLVE_LOG_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let log_path = std::env::temp_dir().join(format!("lp_diff_solver_{}_{log_seq}.log", std::process::id()));
 
     let BuiltModel { row_problem, sense, variable_names, sorted_var_ids, objective_coefficients, row_constraint_names, skipped_sos } =
         model;
@@ -926,6 +931,37 @@ mod tests {
         assert!(status_is_infeasible("UnboundedOrInfeasible"));
         assert!(!status_is_infeasible("Optimal"));
         assert!(!status_is_infeasible("Unbounded"));
+    }
+
+    #[test]
+    fn test_concurrent_solves_do_not_clobber_solver_log() {
+        // "Solve both" runs two solve_problem calls concurrently in one process:
+        // the fast solve must not delete the slow solve's log out from under it.
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let slow_input = std::fs::read_to_string(root.join("../rust/resources/mps/fit2d.mps")).expect("failed to read fit2d.mps");
+        let slow = LpProblem::parse_mps(&slow_input).expect("failed to parse fit2d.mps");
+        let fast = LpProblem::parse("min\nobj: x\nst\nc1: x >= 1\nend").expect("failed to parse tiny LP");
+
+        // Stagger the fast solve across the slow solve's window so it finishes
+        // (and cleans up its log) while the slow solve is still running.
+        for stagger_ms in [0u64, 10, 25, 50, 75] {
+            std::thread::scope(|scope| {
+                let slow_handle = scope.spawn(|| solve_problem(&slow));
+                let fast_ref = &fast;
+                let fast_handle = scope.spawn(move || {
+                    std::thread::sleep(Duration::from_millis(stagger_ms));
+                    solve_problem(fast_ref)
+                });
+                fast_handle
+                    .join()
+                    .expect("fast solver thread panicked")
+                    .unwrap_or_else(|e| panic!("fast solve failed at stagger {stagger_ms}ms: {e}"));
+                slow_handle
+                    .join()
+                    .expect("slow solver thread panicked")
+                    .unwrap_or_else(|e| panic!("slow solve failed at stagger {stagger_ms}ms: {e}"));
+            });
+        }
     }
 
     #[test]

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -5,7 +5,7 @@ use ratatui::widgets::ListState;
 
 use crate::diff_model::{DiffEntry, DiffKind, sort_indices_by_delta};
 use crate::solver::{InfeasibilityDiagnosis, SolveDiffResult, SolveResult};
-use crate::widgets::{kind_prefix, kind_style};
+use crate::widgets::{kind_prefix, kind_style, text};
 
 /// State machine for the LP solver overlay.
 #[derive(Debug)]
@@ -159,6 +159,29 @@ pub struct SearchResult {
     pub haystack_index: usize,
     /// Diff kind for badge rendering.
     pub kind: DiffKind,
+}
+
+/// Which top-level mode the viewer is running in.
+///
+/// Selected once at startup from the number of positional file arguments and
+/// never changes afterwards: one file → [`AppMode::Inspect`] (a single-model
+/// explorer), two files → [`AppMode::Diff`] (the original diff viewer). An
+/// explicit enum keeps mode-specific behaviour readable instead of scattered
+/// `Option`/count checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppMode {
+    /// Comparing two files: the original diff experience, unchanged.
+    Diff,
+    /// Exploring a single file: sections list every entry with no diff badges.
+    Inspect,
+}
+
+impl AppMode {
+    /// Whether diff-badges/kinds should be shown in the sidebar and detail panel.
+    /// Inspect mode lists plain entries with no `[+]/[-]/[~]` prefixes or colours.
+    pub const fn shows_diff_badges(self) -> bool {
+        matches!(self, Self::Diff)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -396,7 +419,18 @@ impl SectionViewState {
 
     /// Recompute the filtered indices and cached sidebar lines from the given
     /// entries, filter, and sort mode.
-    pub(crate) fn recompute<T: DiffEntry>(&mut self, entries: &[T], filter: DiffFilter, ignore_order: bool, sort: SortMode) {
+    ///
+    /// `show_badges` gates the `[+]/[-]/[~]` diff prefix and its colour: diff mode
+    /// passes `true`; inspect mode passes `false` so entries render as plain,
+    /// neutrally-coloured names with no diff decoration.
+    pub(crate) fn recompute<T: DiffEntry>(
+        &mut self,
+        entries: &[T],
+        filter: DiffFilter,
+        ignore_order: bool,
+        sort: SortMode,
+        show_badges: bool,
+    ) {
         debug_assert!(self.dirty, "recompute called on non-dirty SectionViewState");
         self.filtered_indices.clear();
         self.cached_lines.clear();
@@ -415,10 +449,14 @@ impl SectionViewState {
         }
         for &i in &self.filtered_indices {
             let entry = &entries[i];
-            let kind = entry.kind();
-            let style = kind_style(kind);
-            let line =
-                Line::from(vec![Span::styled(kind_prefix(kind), style), Span::raw(" "), Span::styled(entry.name().to_owned(), style)]);
+            let line = if show_badges {
+                let kind = entry.kind();
+                let style = kind_style(kind);
+                Line::from(vec![Span::styled(kind_prefix(kind), style), Span::raw(" "), Span::styled(entry.name().to_owned(), style)])
+            } else {
+                // Inspect mode: plain name, no diff badge, default text colour.
+                Line::from(vec![Span::raw("  "), Span::styled(entry.name().to_owned(), text())])
+            };
             self.cached_lines.push(line);
         }
         debug_assert_eq!(self.filtered_indices.len(), self.cached_lines.len(), "filtered indices and cached lines must be in sync");
@@ -558,6 +596,31 @@ impl PaletteCommand {
         }
     }
 
+    /// Whether this command is offered in inspect (single-file) mode.
+    ///
+    /// Diff-only actions — kind filters, ignore-order, tolerance cycling, the raw
+    /// side-by-side view, delta sorts, and the per-side (file 1 / file 2) yanks —
+    /// are hidden from the palette in inspect mode (they also no-op with a status
+    /// hint if their direct key is pressed). Everything else, including search,
+    /// solve, CSV export, name/detail yank, help and quit, remains.
+    pub const fn available_in_inspect(self) -> bool {
+        !matches!(
+            self,
+            Self::FilterAll
+                | Self::FilterAdded
+                | Self::FilterRemoved
+                | Self::FilterModified
+                | Self::FilterRenamed
+                | Self::ToggleRawView
+                | Self::ToggleIgnoreOrder
+                | Self::CycleSort
+                | Self::CycleRelTol
+                | Self::CycleAbsTol
+                | Self::YankOld
+                | Self::YankNew
+        )
+    }
+
     /// The equivalent direct keybinding, shown right-aligned in the palette.
     pub const fn hint(self) -> &'static str {
         match self {
@@ -585,6 +648,61 @@ impl PaletteCommand {
             Self::YankDetail => "Y",
             Self::ShowHelp => "?",
             Self::Quit => "q",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_diff_mode_shows_badges_inspect_does_not() {
+        assert!(AppMode::Diff.shows_diff_badges(), "diff mode decorates entries with kind badges");
+        assert!(!AppMode::Inspect.shows_diff_badges(), "inspect mode lists plain entries");
+    }
+
+    #[test]
+    fn test_diff_only_palette_commands_hidden_in_inspect() {
+        // Diff-only actions: kind filters, ignore-order, tolerance, raw view, delta sorts.
+        let disabled = [
+            PaletteCommand::FilterAll,
+            PaletteCommand::FilterAdded,
+            PaletteCommand::FilterRemoved,
+            PaletteCommand::FilterModified,
+            PaletteCommand::FilterRenamed,
+            PaletteCommand::ToggleRawView,
+            PaletteCommand::ToggleIgnoreOrder,
+            PaletteCommand::CycleSort,
+            PaletteCommand::CycleRelTol,
+            PaletteCommand::CycleAbsTol,
+            PaletteCommand::YankOld,
+            PaletteCommand::YankNew,
+        ];
+        for command in disabled {
+            assert!(!command.available_in_inspect(), "{command:?} must be hidden in inspect mode");
+        }
+    }
+
+    #[test]
+    fn test_core_palette_commands_available_in_inspect() {
+        // Everything that still does something in a single-file view stays offered.
+        let available = [
+            PaletteCommand::GoSummary,
+            PaletteCommand::GoVariables,
+            PaletteCommand::GoConstraints,
+            PaletteCommand::GoObjectives,
+            PaletteCommand::GoNumerics,
+            PaletteCommand::OpenSearch,
+            PaletteCommand::Solve,
+            PaletteCommand::ExportCsv,
+            PaletteCommand::YankName,
+            PaletteCommand::YankDetail,
+            PaletteCommand::ShowHelp,
+            PaletteCommand::Quit,
+        ];
+        for command in available {
+            assert!(command.available_in_inspect(), "{command:?} must remain available in inspect mode");
         }
     }
 }

--- a/tui/src/ui.rs
+++ b/tui/src/ui.rs
@@ -158,9 +158,11 @@ fn draw_status(
     // Watch-mode indicator, shown alongside the sort/tolerance indicators.
     let watch_reloading = if app.watch.enabled { Some(app.watch.is_reloading()) } else { None };
     // Inspect mode shows the filename and section entry count in place of the
-    // diff change/filter segment.
-    let inspect_file = crate::widgets::short_filename(&app.report.file1);
-    let inspect = if app.mode == AppMode::Inspect {
+    // diff change/filter segment. The filename String is only built (and the
+    // segment only shown) in inspect mode; it lives here so InspectInfo can
+    // borrow it across the draw call below.
+    let inspect_file = (app.mode == AppMode::Inspect).then(|| crate::widgets::short_filename(&app.report.file1));
+    let inspect = inspect_file.as_deref().map(|file| {
         let (label, count) = match app.active_section {
             Section::Variables => ("variables", app.report.variables.entries.len()),
             Section::Constraints => ("constraints", app.report.constraints.entries.len()),
@@ -169,10 +171,8 @@ fn draw_status(
                 ("total", app.report.variables.entries.len() + app.report.constraints.entries.len() + app.report.objectives.entries.len())
             }
         };
-        Some(status_bar::InspectInfo { file: &inspect_file, section_label: label, entry_count: count })
-    } else {
-        None
-    };
+        status_bar::InspectInfo { file, section_label: label, entry_count: count }
+    });
     status_bar::draw_status_bar(
         frame,
         area,

--- a/tui/src/ui.rs
+++ b/tui/src/ui.rs
@@ -19,7 +19,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
-use crate::app::{App, Focus, Section};
+use crate::app::{App, AppMode, Focus, Section};
 use crate::state::DetailView;
 use crate::theme::theme;
 use crate::widgets::{
@@ -88,6 +88,38 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     draw_detail_panel(frame, detail_area, app);
 
     // Status bar (drawn after detail so detail_content_lines is populated).
+    draw_status(frame, outer[2], app, &report_summary, total_changes, filter_count);
+
+    // Search pop-up overlay — rendered on top of main content.
+    if app.search_popup.visible {
+        search_popup::draw_search_popup(frame, frame.area(), app);
+    }
+
+    // Command palette overlay.
+    if app.palette.visible {
+        palette::draw_palette(frame, frame.area(), app);
+    }
+
+    // Solve overlay — rendered on top of main content.
+    if !matches!(app.solver.state, crate::state::SolveState::Idle) {
+        solve::draw_solve_overlay(frame, frame.area(), app);
+    }
+
+    // Help overlay — rendered last so it draws on top of everything.
+    if app.show_help {
+        help::draw_help(frame, frame.area(), app);
+    }
+}
+
+/// Draw the bottom status bar, choosing the diff or inspect left segment.
+fn draw_status(
+    frame: &mut Frame,
+    area: Rect,
+    app: &App,
+    report_summary: &crate::diff_model::DiffSummary,
+    total_changes: usize,
+    filter_count: usize,
+) {
     let detail_pos = if app.focus == Focus::Detail && app.layout.detail_content_lines > 0 {
         Some(status_bar::DetailPosition { scroll: app.detail_scroll, content_lines: app.layout.detail_content_lines })
     } else {
@@ -125,9 +157,25 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     };
     // Watch-mode indicator, shown alongside the sort/tolerance indicators.
     let watch_reloading = if app.watch.enabled { Some(app.watch.is_reloading()) } else { None };
+    // Inspect mode shows the filename and section entry count in place of the
+    // diff change/filter segment.
+    let inspect_file = crate::widgets::short_filename(&app.report.file1);
+    let inspect = if app.mode == AppMode::Inspect {
+        let (label, count) = match app.active_section {
+            Section::Variables => ("variables", app.report.variables.entries.len()),
+            Section::Constraints => ("constraints", app.report.constraints.entries.len()),
+            Section::Objectives => ("objectives", app.report.objectives.entries.len()),
+            Section::Summary | Section::Numerics => {
+                ("total", app.report.variables.entries.len() + app.report.constraints.entries.len() + app.report.objectives.entries.len())
+            }
+        };
+        Some(status_bar::InspectInfo { file: &inspect_file, section_label: label, entry_count: count })
+    } else {
+        None
+    };
     status_bar::draw_status_bar(
         frame,
-        outer[2],
+        area,
         &status_bar::StatusBarParams {
             total_changes,
             section_counts: &section_counts,
@@ -139,28 +187,9 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
             sort_label: app.sort_mode.label(),
             tolerance_label: tolerance_label.as_deref(),
             watch_reloading,
+            inspect,
         },
     );
-
-    // Search pop-up overlay — rendered on top of main content.
-    if app.search_popup.visible {
-        search_popup::draw_search_popup(frame, frame.area(), app);
-    }
-
-    // Command palette overlay.
-    if app.palette.visible {
-        palette::draw_palette(frame, frame.area(), app);
-    }
-
-    // Solve overlay — rendered on top of main content.
-    if !matches!(app.solver.state, crate::state::SolveState::Idle) {
-        solve::draw_solve_overlay(frame, frame.area(), app);
-    }
-
-    // Help overlay — rendered last so it draws on top of everything.
-    if app.show_help {
-        help::draw_help(frame, frame.area(), app);
-    }
 }
 
 /// Render a centred "terminal too small" hint for sub-minimum window sizes.
@@ -176,6 +205,28 @@ fn draw_too_small(frame: &mut Frame, area: Rect) {
     #[allow(clippy::cast_possible_truncation)] // tiny fixed message
     let popup = centred_rect(area, 24.min(area.width), (lines.len() as u16).min(area.height));
     frame.render_widget(Paragraph::new(lines).centered(), popup);
+}
+
+/// Render the neutral single-model detail for the selected inspect entry.
+/// Returns the total content line count.
+fn draw_inspect_detail(frame: &mut Frame, area: Rect, app: &App, entry_index: usize, border_style: Style) -> usize {
+    let scroll = app.detail_scroll;
+    let interner = &app.report.interner;
+    match app.active_section {
+        Section::Variables => {
+            debug_assert!(entry_index < app.report.variables.entries.len(), "variable entry_index {entry_index} out of bounds");
+            detail::render_inspect_variable(frame, area, &app.report.variables.entries[entry_index], border_style, scroll)
+        }
+        Section::Constraints => {
+            debug_assert!(entry_index < app.report.constraints.entries.len(), "constraint entry_index {entry_index} out of bounds");
+            detail::render_inspect_constraint(frame, area, &app.report.constraints.entries[entry_index], border_style, scroll, interner)
+        }
+        Section::Objectives => {
+            debug_assert!(entry_index < app.report.objectives.entries.len(), "objective entry_index {entry_index} out of bounds");
+            detail::render_inspect_objective(frame, area, &app.report.objectives.entries[entry_index], border_style, scroll, interner)
+        }
+        Section::Summary | Section::Numerics => unreachable!("static sections are handled by draw_detail_panel"),
+    }
 }
 
 /// Draw the detail panel on the right side.
@@ -194,47 +245,58 @@ fn draw_detail_panel(frame: &mut Frame, area: ratatui::layout::Rect, app: &mut A
         frame.render_widget(block, area);
         summary::draw_summary(frame, inner, &app.numerics_lines, app.detail_scroll)
     } else if let Some(entry_index) = app.selected_entry_index() {
-        // Check for raw view mode on supported sections (Constraints, Objectives).
-        let use_raw = app.detail_view == DetailView::Raw && matches!(app.active_section, Section::Constraints | Section::Objectives);
-
-        if use_raw {
-            let (old_text, new_text) = app.extract_raw_texts();
-            // Variables show a message; Constraints/Objectives show the raw text.
-            raw_diff::draw_raw_diff(frame, area, old_text, new_text, app.detail_scroll, border_style)
+        // Inspect mode renders each entry as a neutral single-model view.
+        if app.mode == AppMode::Inspect {
+            draw_inspect_detail(frame, area, app, entry_index, border_style)
         } else {
-            app.ensure_coeff_row_cache();
-            let scroll = app.detail_scroll;
-            let cached_rows = app.cached_coeff_rows();
-            match app.active_section {
-                Section::Variables => {
-                    debug_assert!(entry_index < app.report.variables.entries.len(), "variable entry_index {entry_index} out of bounds");
-                    detail::render_variable_detail(frame, area, &app.report.variables.entries[entry_index], border_style, scroll)
+            // Check for raw view mode on supported sections (Constraints, Objectives).
+            let use_raw = app.detail_view == DetailView::Raw && matches!(app.active_section, Section::Constraints | Section::Objectives);
+
+            if use_raw {
+                let (old_text, new_text) = app.extract_raw_texts();
+                // Variables show a message; Constraints/Objectives show the raw text.
+                raw_diff::draw_raw_diff(frame, area, old_text, new_text, app.detail_scroll, border_style)
+            } else {
+                app.ensure_coeff_row_cache();
+                let scroll = app.detail_scroll;
+                let cached_rows = app.cached_coeff_rows();
+                match app.active_section {
+                    Section::Variables => {
+                        debug_assert!(entry_index < app.report.variables.entries.len(), "variable entry_index {entry_index} out of bounds");
+                        detail::render_variable_detail(frame, area, &app.report.variables.entries[entry_index], border_style, scroll)
+                    }
+                    Section::Constraints => {
+                        debug_assert!(
+                            entry_index < app.report.constraints.entries.len(),
+                            "constraint entry_index {entry_index} out of bounds"
+                        );
+                        detail::render_constraint_detail(
+                            frame,
+                            area,
+                            &app.report.constraints.entries[entry_index],
+                            border_style,
+                            scroll,
+                            cached_rows,
+                            &app.report.interner,
+                        )
+                    }
+                    Section::Objectives => {
+                        debug_assert!(
+                            entry_index < app.report.objectives.entries.len(),
+                            "objective entry_index {entry_index} out of bounds"
+                        );
+                        detail::render_objective_detail(
+                            frame,
+                            area,
+                            &app.report.objectives.entries[entry_index],
+                            border_style,
+                            scroll,
+                            cached_rows,
+                            &app.report.interner,
+                        )
+                    }
+                    Section::Summary | Section::Numerics => unreachable!("handled above"),
                 }
-                Section::Constraints => {
-                    debug_assert!(entry_index < app.report.constraints.entries.len(), "constraint entry_index {entry_index} out of bounds");
-                    detail::render_constraint_detail(
-                        frame,
-                        area,
-                        &app.report.constraints.entries[entry_index],
-                        border_style,
-                        scroll,
-                        cached_rows,
-                        &app.report.interner,
-                    )
-                }
-                Section::Objectives => {
-                    debug_assert!(entry_index < app.report.objectives.entries.len(), "objective entry_index {entry_index} out of bounds");
-                    detail::render_objective_detail(
-                        frame,
-                        area,
-                        &app.report.objectives.entries[entry_index],
-                        border_style,
-                        scroll,
-                        cached_rows,
-                        &app.report.interner,
-                    )
-                }
-                Section::Summary | Section::Numerics => unreachable!("handled above"),
             }
         }
     } else {

--- a/tui/src/widgets/detail.rs
+++ b/tui/src/widgets/detail.rs
@@ -19,7 +19,7 @@ use crate::diff_model::{
     VariableDiffEntry,
 };
 use crate::theme::theme;
-use crate::widgets::{ARROW, bold_text, kind_colour, muted, panel_block, truncate_with_ellipsis};
+use crate::widgets::{ARROW, bold_text, kind_colour, muted, panel_block, text, truncate_with_ellipsis};
 
 /// Horizontal rule used as a visual separator below the entry header.
 fn rule<'a>() -> Line<'a> {
@@ -407,6 +407,102 @@ pub fn render_objective_detail(
     }
 
     render_panel(frame, area, " Objective Detail ", lines, border_style, scroll)
+}
+
+/// Build the neutral header lines for an inspect detail panel: entity label,
+/// name (bold), and a rule. No diff badge — inspect shows a single model.
+fn inspect_header(entity_label: &str, name: &str) -> Vec<Line<'static>> {
+    vec![Line::from(vec![Span::styled(format!("{entity_label}: "), muted()), Span::styled(name.to_owned(), bold_text())]), rule()]
+}
+
+/// Render an inspect (single-file) variable detail panel: type and bounds,
+/// all in the neutral text colour. Returns the total content line count.
+pub fn render_inspect_variable(frame: &mut Frame, area: Rect, entry: &VariableDiffEntry, border_style: Style, scroll: u16) -> usize {
+    if area.width == 0 || area.height == 0 {
+        return 0;
+    }
+    let mut lines = inspect_header("Variable", &entry.name);
+    // Inspect entries always carry the single-file value on the `new` side.
+    if let Some(variable_type) = entry.new_type.as_ref() {
+        render_variable_type_info(&mut lines, variable_type, text());
+    }
+    render_panel(frame, area, " Variable Detail ", lines, border_style, scroll)
+}
+
+/// Render an inspect (single-file) constraint detail panel: operator, RHS, and
+/// coefficients (or SOS type and weights), neutrally coloured.
+pub fn render_inspect_constraint(
+    frame: &mut Frame,
+    area: Rect,
+    entry: &ConstraintDiffEntry,
+    border_style: Style,
+    scroll: u16,
+    interner: &NameInterner,
+) -> usize {
+    if area.width == 0 || area.height == 0 {
+        return 0;
+    }
+    let t = theme();
+    let mut lines = inspect_header("Constraint", &entry.name);
+
+    // Source location (inspect builds the model on the `new`/file-2 side).
+    if let Some(line) = entry.line_file2.or(entry.line_file1) {
+        lines
+            .push(Line::from(vec![Span::styled("  Location: ", muted()), Span::styled(format!("L{line}"), Style::default().fg(t.accent))]));
+    }
+
+    match &entry.detail {
+        ConstraintDiffDetail::AddedOrRemoved(ResolvedConstraint::Standard { coefficients, operator, rhs }) => {
+            lines.push(Line::from(vec![Span::styled("  Operator: ", muted()), Span::styled(format!("{operator}"), text())]));
+            lines.push(Line::from(vec![Span::styled("  RHS:      ", muted()), Span::styled(format!("{rhs}"), text())]));
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled("  Coefficients:", muted().add_modifier(Modifier::BOLD))));
+            render_inspect_coefficients(&mut lines, coefficients, interner);
+        }
+        ConstraintDiffDetail::AddedOrRemoved(ResolvedConstraint::Sos { sos_type, weights }) => {
+            lines.push(Line::from(vec![Span::styled("  SOS Type: ", muted()), Span::styled(format!("{sos_type}"), text())]));
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled("  Weights:", muted().add_modifier(Modifier::BOLD))));
+            render_inspect_coefficients(&mut lines, weights, interner);
+        }
+        // Inspect always diffs against an empty base, so every constraint is an
+        // AddedOrRemoved single-side entry; other variants cannot occur.
+        _ => {
+            debug_assert!(false, "inspect constraint detail must be AddedOrRemoved");
+            lines.push(Line::from(Span::styled("  (unavailable)", muted())));
+        }
+    }
+
+    render_panel(frame, area, " Constraint Detail ", lines, border_style, scroll)
+}
+
+/// Render an inspect (single-file) objective detail panel: coefficients, neutral.
+pub fn render_inspect_objective(
+    frame: &mut Frame,
+    area: Rect,
+    entry: &ObjectiveDiffEntry,
+    border_style: Style,
+    scroll: u16,
+    interner: &NameInterner,
+) -> usize {
+    if area.width == 0 || area.height == 0 {
+        return 0;
+    }
+    let mut lines = inspect_header("Objective", &entry.name);
+    lines.push(Line::from(Span::styled("  Coefficients:", muted().add_modifier(Modifier::BOLD))));
+    render_inspect_coefficients(&mut lines, &entry.new_coefficients, interner);
+    render_panel(frame, area, " Objective Detail ", lines, border_style, scroll)
+}
+
+/// Append neutral `name  value` rows for a resolved coefficient/weight list.
+fn render_inspect_coefficients(lines: &mut Vec<Line<'static>>, coefficients: &[ResolvedCoefficient], interner: &NameInterner) {
+    for coeff in coefficients {
+        let name = interner.resolve(coeff.name);
+        lines.push(Line::from(vec![
+            Span::styled(format!("    {:<20}", truncate_with_ellipsis(name, 20)), text()),
+            Span::styled(format!("{}", coeff.value), text()),
+        ]));
+    }
 }
 
 /// Render a side-by-side old/new coefficient comparison for modified

--- a/tui/src/widgets/help.rs
+++ b/tui/src/widgets/help.rs
@@ -76,21 +76,67 @@ const HELP_TEXT: &[&str] = &[
     "",
 ];
 
+/// Inspect-mode keybindings: diff-only actions (filters, tolerance, raw view,
+/// delta sorts, side yanks) are omitted since they do not apply to a single file.
+const INSPECT_HELP_TEXT: &[&str] = &[
+    "",
+    "  Single-file inspect mode",
+    "  ───────────────────────",
+    "",
+    "  Navigation                              Other",
+    "  ─────────                               ─────",
+    "  j / ↓   Down                            /   Search",
+    "  k / ↑   Up                              Ctrl-p  Command palette",
+    "  g / Home Top                             ?   This help",
+    "  G / End  Bottom                          q   Quit",
+    "  [ / ]   Prev/next section                Ctrl-C  Force quit",
+    "  n / N   Down / Up",
+    "  Ctrl-d / Ctrl-u  Half page ↓ / ↑        Clipboard",
+    "  Ctrl-f / Ctrl-b  Full page ↓ / ↑        ─────────",
+    "  Ctrl-o / Ctrl-i  Jump back / forward    yy  Yank name",
+    "  Tab / ⇧Tab  Next / prev panel           Y   Yank detail",
+    "  Enter   Go to detail                    w   Export CSV (objectives,",
+    "  h / l   Sidebar / Detail                    constraints, variables)",
+    "  1–5     Jump to section (5: Numerics)    S   Solve this model",
+    "  Esc     Back",
+    "",
+    "  Search (Telescope-style pop-up)",
+    "  ──────────────────────────────",
+    "  /         Open search pop-up",
+    "  Tab       Complete with selected name",
+    "  Enter     Jump to selected entry",
+    "  Esc       Cancel search",
+    "  query / r:pattern / s:text   Fuzzy / regex / substring",
+    "",
+    "  Filters, tolerance, raw diff and delta sorts are diff-only",
+    "  and are unavailable when inspecting a single file.",
+    "",
+    "  Mouse: scroll wheel navigates, click selects",
+    "",
+];
+
 const POPUP_WIDTH: u16 = 60;
-/// Desired popup height: all help lines plus top/bottom borders. Clamped to the
-/// terminal at draw time, so on short terminals the content scrolls instead of
-/// being silently truncated.
-const fn desired_height() -> u16 {
+/// Desired popup height for a given help text: all lines plus top/bottom borders.
+/// Clamped to the terminal at draw time, so on short terminals the content
+/// scrolls instead of being silently truncated.
+const fn desired_height(text: &[&str]) -> u16 {
     #[allow(clippy::cast_possible_truncation)] // help text is a few dozen lines
-    let lines = HELP_TEXT.len() as u16;
+    let lines = text.len() as u16;
     lines.saturating_add(2)
 }
 
-/// Pre-built help text lines, cached to avoid per-frame allocation.
+/// Pre-built diff help text lines, cached to avoid per-frame allocation.
 static HELP_LINES: LazyLock<Vec<Line<'static>>> = LazyLock::new(|| {
     let t = theme();
     let text_style = Style::default().fg(t.text);
     HELP_TEXT.iter().map(|&s| Line::from(Span::styled(s, text_style))).collect()
+});
+
+/// Pre-built inspect help text lines, cached to avoid per-frame allocation.
+static INSPECT_HELP_LINES: LazyLock<Vec<Line<'static>>> = LazyLock::new(|| {
+    let t = theme();
+    let text_style = Style::default().fg(t.text);
+    INSPECT_HELP_TEXT.iter().map(|&s| Line::from(Span::styled(s, text_style))).collect()
 });
 
 /// Draw a centred help pop-up overlay on top of the current frame.
@@ -104,11 +150,15 @@ pub fn draw_help(frame: &mut Frame, area: Rect, app: &mut App) {
     if area.width == 0 || area.height == 0 {
         return;
     }
-    let popup = super::centred_rect(area, POPUP_WIDTH, desired_height());
+    let inspect = app.mode == crate::state::AppMode::Inspect;
+    let (help_text, help_lines): (&[&str], &LazyLock<Vec<Line<'static>>>) =
+        if inspect { (INSPECT_HELP_TEXT, &INSPECT_HELP_LINES) } else { (HELP_TEXT, &HELP_LINES) };
+
+    let popup = super::centred_rect(area, POPUP_WIDTH, desired_height(help_text));
 
     let inner_height = popup.height.saturating_sub(2) as usize;
     #[allow(clippy::cast_possible_truncation)] // help text is a few dozen lines
-    let max_scroll = HELP_TEXT.len().saturating_sub(inner_height) as u16;
+    let max_scroll = help_text.len().saturating_sub(inner_height) as u16;
     app.help_scroll = app.help_scroll.min(max_scroll);
 
     let t = theme();
@@ -116,7 +166,7 @@ pub fn draw_help(frame: &mut Frame, area: Rect, app: &mut App) {
     let title = if max_scroll > 0 { " Keybindings  (j/k scroll · Esc close) " } else { " Keybindings " };
     let block = panel_block(border_style).title(Span::styled(title, border_style));
 
-    let paragraph = Paragraph::new(HELP_LINES.clone()).block(block).scroll((app.help_scroll, 0));
+    let paragraph = Paragraph::new((**help_lines).clone()).block(block).scroll((app.help_scroll, 0));
 
     frame.render_widget(Clear, popup);
     frame.render_widget(paragraph, popup);

--- a/tui/src/widgets/mod.rs
+++ b/tui/src/widgets/mod.rs
@@ -7,6 +7,8 @@ use ratatui::layout::{Constraint, Flex, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{Block, BorderType, Borders, Scrollbar, ScrollbarOrientation};
 
+use lp_parser_rs::analysis::IssueSeverity;
+
 use crate::diff_model::DiffKind;
 use crate::state::Focus;
 use crate::theme::theme;
@@ -145,6 +147,21 @@ pub const fn kind_prefix(kind: DiffKind) -> &'static str {
         DiffKind::Modified => "[~]",
         DiffKind::Renamed => "[>]",
     }
+}
+
+/// Map an [`IssueSeverity`] to its theme-aware colour.
+pub fn severity_colour(severity: IssueSeverity) -> Color {
+    let t = theme();
+    match severity {
+        IssueSeverity::Error => t.error,
+        IssueSeverity::Warning => t.warning,
+        IssueSeverity::Info => t.info,
+    }
+}
+
+/// Extract the filename from a path string for compact display.
+pub fn short_filename(path: &str) -> String {
+    std::path::Path::new(path).file_name().map_or_else(|| path.to_owned(), |name| name.to_string_lossy().into_owned())
 }
 
 /// Compute a centred rectangle of the given dimensions, clamped to the terminal area.

--- a/tui/src/widgets/mod.rs
+++ b/tui/src/widgets/mod.rs
@@ -3,11 +3,10 @@
 use std::borrow::Cow;
 use std::time::Duration;
 
+use lp_parser_rs::analysis::IssueSeverity;
 use ratatui::layout::{Constraint, Flex, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{Block, BorderType, Borders, Scrollbar, ScrollbarOrientation};
-
-use lp_parser_rs::analysis::IssueSeverity;
 
 use crate::diff_model::DiffKind;
 use crate::state::Focus;

--- a/tui/src/widgets/numerics.rs
+++ b/tui/src/widgets/numerics.rs
@@ -6,7 +6,7 @@
 //! in file 2. Lines are pre-built and cached on `App` (like `summary_lines`)
 //! and rebuilt whenever the report is rebuilt (tolerance change, watch reload).
 
-use lp_parser_rs::analysis::{AnalysisIssue, IssueCategory, IssueSeverity, RangeStats};
+use lp_parser_rs::analysis::{AnalysisIssue, IssueCategory, IssueSeverity, ProblemAnalysis, RangeStats};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
@@ -234,6 +234,84 @@ pub fn build_numerics_lines(report: &LpDiffReport) -> Vec<Line<'static>> {
     }
 
     lines
+}
+
+/// Build the cached styled lines for the inspect (single-file) Numerics panel.
+///
+/// Same per-file conditioning analysis as diff mode, rendered as a single column.
+pub fn build_inspect_numerics_lines(file: &str, analysis: &ProblemAnalysis) -> Vec<Line<'static>> {
+    let t = theme();
+    let mut lines: Vec<Line<'static>> = Vec::with_capacity(32);
+
+    lines.push(Line::from(vec![Span::raw("  "), Span::styled(file.to_owned(), Style::default().fg(t.text))]));
+    lines.push(Line::from(""));
+
+    // Problem size.
+    heading(&mut lines, "Problem Size");
+    inspect_value_row(&mut lines, "Variables", &analysis.summary.variable_count.to_string());
+    inspect_value_row(&mut lines, "Constraints", &analysis.summary.constraint_count.to_string());
+    inspect_value_row(&mut lines, "Non-zeros", &analysis.summary.total_nonzeros.to_string());
+    inspect_value_row(&mut lines, "Density", &density_cell(analysis.summary.density));
+    inspect_value_row(
+        &mut lines,
+        "Vars/constraint",
+        &format!("{}\u{2013}{}", analysis.sparsity.min_vars_per_constraint, analysis.sparsity.max_vars_per_constraint),
+    );
+    lines.push(Line::from(""));
+
+    // Coefficient magnitude ranges + ratio.
+    heading(&mut lines, "Coefficient Ranges (|value|)");
+    inspect_range_rows(&mut lines, "Objective", &analysis.coefficients.objective_coeff_range);
+    inspect_range_rows(&mut lines, "Matrix", &analysis.coefficients.constraint_coeff_range);
+    inspect_range_rows(&mut lines, "RHS", &analysis.constraints.rhs_range);
+
+    let overall = Some(analysis.coefficients.coefficient_ratio);
+    lines.push(Line::from(vec![
+        Span::styled(format!("  {:<LABEL_WIDTH$}", "Overall ratio"), Style::default().fg(t.text).add_modifier(Modifier::BOLD)),
+        Span::styled(ratio_cell(overall), Style::default().fg(ratio_colour(overall))),
+    ]));
+    lines.push(Line::from(vec![Span::styled(
+        format!("  ratio > {RATIO_WARN_THRESHOLD:.0e} risks precision loss; > {RATIO_ERROR_THRESHOLD:.0e} is likely to break solvers"),
+        Style::default().fg(t.muted),
+    )]));
+    lines.push(Line::from(""));
+
+    // Issues.
+    heading(&mut lines, "Issues");
+    issue_count_row(&mut lines, "File", count_by_severity(&analysis.issues));
+    if analysis.issues.is_empty() {
+        lines.push(Line::from(vec![Span::styled("  No issues detected", Style::default().fg(t.muted))]));
+    } else {
+        lines.push(Line::from(""));
+        for issue in &analysis.issues {
+            lines.push(Line::from(vec![
+                Span::styled(format!("  [{:<7}] ", issue.severity.to_string()), Style::default().fg(severity_colour(issue.severity))),
+                Span::styled(issue.message.clone(), Style::default().fg(t.text)),
+            ]));
+        }
+    }
+
+    lines
+}
+
+/// Append a single-column labelled value row for the inspect Numerics panel.
+fn inspect_value_row(lines: &mut Vec<Line<'static>>, label: &str, value: &str) {
+    let t = theme();
+    lines.push(Line::from(vec![
+        Span::styled(format!("  {label:<LABEL_WIDTH$}"), Style::default().fg(t.text)),
+        Span::styled(format!("{value:>VALUE_WIDTH$}"), Style::default().fg(t.text)),
+    ]));
+}
+
+/// Append the min/max interval and its ratio for a single `RangeStats` (inspect).
+fn inspect_range_rows(lines: &mut Vec<Line<'static>>, label: &str, range: &RangeStats) {
+    let t = theme();
+    inspect_value_row(lines, label, &format_range(range));
+    let ratio = range_ratio(range);
+    lines.push(Line::from(vec![
+        Span::styled(format!("  {:<LABEL_WIDTH$}", format!("{label} ratio")), Style::default().fg(t.muted)),
+        Span::styled(ratio_cell(ratio), Style::default().fg(ratio_colour(ratio))),
+    ]));
 }
 
 /// Append a bold accent heading line.

--- a/tui/src/widgets/numerics.rs
+++ b/tui/src/widgets/numerics.rs
@@ -12,7 +12,7 @@ use ratatui::text::{Line, Span};
 
 use crate::diff_model::LpDiffReport;
 use crate::theme::theme;
-use crate::widgets::{ARROW, gauge_bar};
+use crate::widgets::{ARROW, gauge_bar, severity_colour, short_filename};
 
 /// Range-ratio threshold above which the value is styled as a warning.
 /// Aligned with `AnalysisConfig::default().coefficient_ratio_threshold` (1e6).
@@ -295,20 +295,6 @@ fn issue_count_row(lines: &mut Vec<Line<'static>>, label: &str, (errors, warning
 
 const fn plural(count: usize) -> &'static str {
     if count == 1 { "" } else { "s" }
-}
-
-fn severity_colour(severity: IssueSeverity) -> Color {
-    let t = theme();
-    match severity {
-        IssueSeverity::Error => t.error,
-        IssueSeverity::Warning => t.warning,
-        IssueSeverity::Info => t.info,
-    }
-}
-
-/// Extract the filename from a path string for compact display.
-fn short_filename(path: &str) -> String {
-    std::path::Path::new(path).file_name().map_or_else(|| path.to_owned(), |name| name.to_string_lossy().into_owned())
 }
 
 #[cfg(test)]

--- a/tui/src/widgets/search_popup.rs
+++ b/tui/src/widgets/search_popup.rs
@@ -111,21 +111,26 @@ fn draw_search_input(frame: &mut Frame, area: Rect, query: &str, mode_label: &st
 
 /// Build pre-styled `Line`s for all search results, to be cached on `SearchPopupState`.
 ///
-/// Called once per query change rather than every frame.
-pub fn build_result_lines(results: &[SearchResult], names: &[String]) -> Vec<Line<'static>> {
+/// Called once per query change rather than every frame. `show_badges` gates the
+/// `[+]/[-]/[~]` diff prefix and its colour (mirroring the sidebar): diff mode
+/// passes `true`; inspect mode passes `false` so results render as plain,
+/// neutrally-coloured names with only the section tag.
+pub fn build_result_lines(results: &[SearchResult], names: &[String], show_badges: bool) -> Vec<Line<'static>> {
     let t = theme();
     results
         .iter()
         .map(|r| {
             let tag = section_tag(r.section);
-            let prefix = kind_prefix(r.kind);
-            let style = kind_style(r.kind);
+            let style = if show_badges { kind_style(r.kind) } else { crate::widgets::text() };
 
             debug_assert!(r.haystack_index < names.len(), "haystack_index {} out of bounds (len {})", r.haystack_index, names.len());
             let name = &names[r.haystack_index];
             let name_spans = build_highlighted_name_owned(name, &r.match_indices, style);
 
-            let mut spans = vec![Span::styled(format!("{tag} "), Style::default().fg(t.muted)), Span::styled(format!("{prefix} "), style)];
+            let mut spans = vec![Span::styled(format!("{tag} "), Style::default().fg(t.muted))];
+            if show_badges {
+                spans.push(Span::styled(format!("{} ", kind_prefix(r.kind)), style));
+            }
             spans.extend(name_spans);
 
             if r.score > 0 {
@@ -208,25 +213,40 @@ fn draw_detail_preview(frame: &mut Frame, area: Rect, app: &App) {
     let selected = app.search_popup.selected.min(app.search_popup.results.len().saturating_sub(1));
     let result = &app.search_popup.results[selected];
     let scroll = app.search_popup.scroll;
+    // Inspect mode previews through the neutral single-model renderers so no
+    // diff badge or added/removed colouring leaks into the pop-up.
+    let inspect = app.mode == crate::state::AppMode::Inspect;
 
     match result.section {
         Section::Variables => {
             if let Some(entry) = app.report.variables.entries.get(result.entry_index) {
-                detail::render_variable_detail(frame, area, entry, border_style, scroll);
+                if inspect {
+                    detail::render_inspect_variable(frame, area, entry, border_style, scroll);
+                } else {
+                    detail::render_variable_detail(frame, area, entry, border_style, scroll);
+                }
             } else {
                 sidebar::draw_empty_detail(frame, area, "Entry not found", border_style);
             }
         }
         Section::Constraints => {
             if let Some(entry) = app.report.constraints.entries.get(result.entry_index) {
-                detail::render_constraint_detail(frame, area, entry, border_style, scroll, None, &app.report.interner);
+                if inspect {
+                    detail::render_inspect_constraint(frame, area, entry, border_style, scroll, &app.report.interner);
+                } else {
+                    detail::render_constraint_detail(frame, area, entry, border_style, scroll, None, &app.report.interner);
+                }
             } else {
                 sidebar::draw_empty_detail(frame, area, "Entry not found", border_style);
             }
         }
         Section::Objectives => {
             if let Some(entry) = app.report.objectives.entries.get(result.entry_index) {
-                detail::render_objective_detail(frame, area, entry, border_style, scroll, None, &app.report.interner);
+                if inspect {
+                    detail::render_inspect_objective(frame, area, entry, border_style, scroll, &app.report.interner);
+                } else {
+                    detail::render_objective_detail(frame, area, entry, border_style, scroll, None, &app.report.interner);
+                }
             } else {
                 sidebar::draw_empty_detail(frame, area, "Entry not found", border_style);
             }
@@ -277,4 +297,46 @@ fn centred_rect(area: Rect) -> Rect {
     let height = ((area.height * 4) / 5).max(15).min(area.height);
 
     super::centred_rect(area, width, height)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff_model::DiffKind;
+
+    fn result(name_index: usize, kind: DiffKind) -> SearchResult {
+        SearchResult { section: Section::Variables, entry_index: 0, score: 0, match_indices: Vec::new(), haystack_index: name_index, kind }
+    }
+
+    /// Concatenate a rendered line's span contents into one string.
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|span| span.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn test_diff_mode_result_lines_carry_kind_badges() {
+        let names = vec!["x1".to_owned()];
+        let lines = build_result_lines(&[result(0, DiffKind::Added)], &names, true);
+        assert_eq!(lines.len(), 1);
+        let text = line_text(&lines[0]);
+        assert!(text.contains("[+]"), "diff mode must show the kind badge, got {text:?}");
+        assert!(text.contains("x1"), "entry name must be present, got {text:?}");
+    }
+
+    #[test]
+    fn test_inspect_mode_result_lines_have_no_badges() {
+        let names = vec!["x1".to_owned()];
+        // Inspect entries are internally Added (diffed against an empty base);
+        // the rendered line must still be badge-free.
+        let lines = build_result_lines(&[result(0, DiffKind::Added)], &names, false);
+        assert_eq!(lines.len(), 1);
+        let text = line_text(&lines[0]);
+        assert!(!text.contains("[+]"), "inspect mode must not show a diff badge, got {text:?}");
+        assert!(text.contains("[var]"), "section tag remains, got {text:?}");
+        assert!(text.contains("x1"), "entry name must be present, got {text:?}");
+        // The name spans use the neutral text style, not the Added colour.
+        let t = theme();
+        let name_span = lines[0].spans.iter().find(|span| span.content.as_ref() == "x1").expect("name span present");
+        assert_eq!(name_span.style.fg, Some(t.text), "name must be neutrally coloured in inspect mode");
+    }
 }

--- a/tui/src/widgets/solve.rs
+++ b/tui/src/widgets/solve.rs
@@ -108,43 +108,59 @@ fn draw_done(
     let active = view.tab;
     let scroll = view.scroll[active.index()];
 
-    // Build tab bar line.
+    // Dynamic lines rebuilt each frame. Kept in owned locals so the reference
+    // list below can borrow them alongside the cached tab lines.
     let tab_bar = build_tab_bar(active);
+    let blank = Line::from("");
+    let footer = Line::from(Span::styled("  1-5: tabs  Tab/S-Tab: cycle  j/k: scroll  y: yank  Esc: close", Style::default().fg(t.muted)));
 
-    // Build content for the active tab, preferring cached lines when available.
-    let mut lines = vec![tab_bar, Line::from("")];
-
-    let cached_tabs = if let SolveRenderCache::Single(tabs) = cache { Some(tabs) } else { None };
-
-    if let Some(tabs) = cached_tabs {
-        lines.extend(tabs[active.index()].iter().cloned());
+    // Prefer cached tab lines; only build from scratch when the cache is absent
+    // (should not happen in normal flow).
+    let mut fallback: Vec<Line<'static>> = Vec::new();
+    let cached: &[Line<'static>] = if let SolveRenderCache::Single(tabs) = cache {
+        &tabs[active.index()]
     } else {
-        // Fallback: build lines from scratch (should not happen in normal flow).
         let inner_width = popup_width.saturating_sub(2);
         match active {
-            SolveTab::Summary => build_summary_tab(&mut lines, result),
-            SolveTab::Variables => build_variables_tab(&mut lines, result, name_column_width(inner_width, 2 + 12 + 14)),
-            SolveTab::Constraints => build_constraints_tab(&mut lines, result, name_column_width(inner_width, 2 + 12 + 14)),
-            SolveTab::Log => build_log_tab(&mut lines, result),
-            SolveTab::Duals => build_duals_tab(&mut lines, result, name_column_width(inner_width, 2 + 14)),
+            SolveTab::Summary => build_summary_tab(&mut fallback, result),
+            SolveTab::Variables => build_variables_tab(&mut fallback, result, name_column_width(inner_width, 2 + 12 + 14)),
+            SolveTab::Constraints => build_constraints_tab(&mut fallback, result, name_column_width(inner_width, 2 + 12 + 14)),
+            SolveTab::Log => build_log_tab(&mut fallback, result),
+            SolveTab::Duals => build_duals_tab(&mut fallback, result, name_column_width(inner_width, 2 + 14)),
         }
-    }
+        &fallback
+    };
 
     // The diagnosis block changes while the background solve runs, so it is
     // appended dynamically rather than baked into the render cache.
+    let mut diag: Vec<Line<'static>> = Vec::new();
     if active == SolveTab::Summary && status_is_infeasible(&result.status) {
-        append_diagnosis_block(&mut lines, diagnosis);
+        append_diagnosis_block(&mut diag, diagnosis);
     }
 
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled("  1-5: tabs  Tab/S-Tab: cycle  j/k: scroll  y: yank  Esc: close", Style::default().fg(t.muted))));
+    // Assemble the render order as references — cached line content is never cloned.
+    let mut lines: Vec<&Line> = Vec::with_capacity(cached.len() + diag.len() + 4);
+    lines.push(&tab_bar);
+    lines.push(&blank);
+    lines.extend(cached.iter());
+    lines.extend(diag.iter());
+    lines.push(&blank);
+    lines.push(&footer);
 
     let block = panel_block(Style::default().fg(t.added).add_modifier(Modifier::BOLD))
         .title(Span::styled(" Solve Results ", Style::default().fg(t.added).add_modifier(Modifier::BOLD)));
-
-    let paragraph = Paragraph::new(lines).block(block).scroll((scroll, 0));
+    let inner = block.inner(popup);
     frame.render_widget(Clear, popup);
-    frame.render_widget(paragraph, popup);
+    frame.render_widget(block, popup);
+
+    // Windowed render honouring vertical scroll (same idiom as `draw_summary`),
+    // clipping long lines to width like the previous unwrapped `Paragraph`.
+    let buf = frame.buffer_mut();
+    for (i, line) in lines.iter().skip(scroll as usize).take(inner.height as usize).enumerate() {
+        #[allow(clippy::cast_possible_truncation)] // i < inner.height (u16)
+        let y = inner.y + i as u16;
+        buf.set_line(inner.x, y, line, inner.width);
+    }
 }
 
 /// Build the tab bar line with the active tab highlighted.

--- a/tui/src/widgets/status_bar.rs
+++ b/tui/src/widgets/status_bar.rs
@@ -25,6 +25,16 @@ pub struct YankFlash<'a> {
     pub message: &'a str,
 }
 
+/// Inspect-mode left segment: the single filename and current section counts.
+///
+/// When present, it replaces the diff-oriented change/filter segment entirely so
+/// no "N changes" / "+N -N ~N" / "filter" text appears in inspect mode.
+pub struct InspectInfo<'a> {
+    pub file: &'a str,
+    pub section_label: &'a str,
+    pub entry_count: usize,
+}
+
 /// Parameters for rendering the status bar.
 pub struct StatusBarParams<'a> {
     pub total_changes: usize,
@@ -40,6 +50,8 @@ pub struct StatusBarParams<'a> {
     pub tolerance_label: Option<&'a str>,
     /// Watch mode: `None` when not watching, `Some(reloading)` when active.
     pub watch_reloading: Option<bool>,
+    /// Inspect-mode left segment. `None` in diff mode (the default segment shows).
+    pub inspect: Option<InspectInfo<'a>>,
 }
 
 /// Key hints shown on the right of the status bar.
@@ -59,21 +71,31 @@ pub fn draw_status_bar(frame: &mut Frame, area: Rect, params: &StatusBarParams<'
     let t = theme();
     let separator = || Span::styled(SEPARATOR, Style::default().fg(t.border));
 
-    // Left: flowing segments — total, per-kind counts, filter, modifiers.
-    let mut spans = vec![
-        Span::styled(format!(" {} changes", params.total_changes), Style::default().fg(t.added).add_modifier(Modifier::BOLD)),
-        separator(),
-        Span::styled(format!("+{}", params.section_counts.added), Style::default().fg(t.added)),
-        Span::raw(" "),
-        Span::styled(format!("-{}", params.section_counts.removed), Style::default().fg(t.removed)),
-        Span::raw(" "),
-        Span::styled(format!("~{}", params.section_counts.modified), Style::default().fg(t.modified)),
-        Span::raw(" "),
-        Span::styled(format!(">{}", params.section_counts.renamed), Style::default().fg(t.info)),
-        separator(),
-        Span::styled("filter:", Style::default().fg(t.muted)),
-        Span::styled(format!("{} ({})", params.filter_label, params.filter_count), Style::default().fg(t.modified)),
-    ];
+    // Left: flowing segments. Inspect mode shows the filename and section count;
+    // diff mode shows total/per-kind change counts and the active filter.
+    let mut spans = if let Some(inspect) = &params.inspect {
+        let entries = if inspect.entry_count == 1 { "entry" } else { "entries" };
+        vec![
+            Span::styled(format!(" {}", inspect.file), Style::default().fg(t.accent).add_modifier(Modifier::BOLD)),
+            separator(),
+            Span::styled(format!("{} {} {}", inspect.entry_count, inspect.section_label, entries), Style::default().fg(t.text)),
+        ]
+    } else {
+        vec![
+            Span::styled(format!(" {} changes", params.total_changes), Style::default().fg(t.added).add_modifier(Modifier::BOLD)),
+            separator(),
+            Span::styled(format!("+{}", params.section_counts.added), Style::default().fg(t.added)),
+            Span::raw(" "),
+            Span::styled(format!("-{}", params.section_counts.removed), Style::default().fg(t.removed)),
+            Span::raw(" "),
+            Span::styled(format!("~{}", params.section_counts.modified), Style::default().fg(t.modified)),
+            Span::raw(" "),
+            Span::styled(format!(">{}", params.section_counts.renamed), Style::default().fg(t.info)),
+            separator(),
+            Span::styled("filter:", Style::default().fg(t.muted)),
+            Span::styled(format!("{} ({})", params.filter_label, params.filter_count), Style::default().fg(t.modified)),
+        ]
+    };
     if params.ignore_order {
         spans.push(Span::styled(" [ignoring order]", Style::default().fg(t.warning)));
     }

--- a/tui/src/widgets/summary.rs
+++ b/tui/src/widgets/summary.rs
@@ -397,4 +397,3 @@ fn format_issue_line(file_label: &str, issue: &lp_parser_rs::analysis::AnalysisI
         Span::styled(issue.message.clone(), Style::default().fg(t.text)),
     ])
 }
-

--- a/tui/src/widgets/summary.rs
+++ b/tui/src/widgets/summary.rs
@@ -55,6 +55,125 @@ pub fn build_summary_lines(
     lines
 }
 
+/// Build pre-formatted Summary lines for inspect (single-file) mode.
+///
+/// Shows the file path, problem name and sense, per-section entry counts, and a
+/// single-column structural analysis (dimensions, variable/constraint types,
+/// coefficient scaling, issues) derived from the file's own `ProblemAnalysis`.
+pub fn build_inspect_summary_lines(
+    file: &str,
+    problem: &lp_parser_rs::problem::LpProblem,
+    summary: &DiffSummary,
+    analysis: &ProblemAnalysis,
+) -> Vec<Line<'static>> {
+    let t = theme();
+    let mut lines: Vec<Line<'static>> = Vec::with_capacity(48);
+
+    // Header: file, name, sense.
+    lines.push(Line::from(vec![Span::raw("  "), Span::styled(file.to_owned(), Style::default().fg(t.text))]));
+    let name = problem.name().unwrap_or("(unnamed)").to_owned();
+    lines.push(Line::from(vec![Span::styled("  Name:   ", muted()), Span::styled(name, Style::default().fg(t.text))]));
+    lines.push(Line::from(vec![
+        Span::styled("  Sense:  ", muted()),
+        Span::styled(problem.sense.to_string(), Style::default().fg(t.accent)),
+    ]));
+    lines.push(Line::from(""));
+
+    // Per-section entry counts (all entries are present; none are "changed").
+    section_heading(&mut lines, "Model Contents");
+    inspect_count_row(&mut lines, "Variables", summary.variables.total());
+    inspect_count_row(&mut lines, "Constraints", summary.constraints.total());
+    inspect_count_row(&mut lines, "Objectives", summary.objectives.total());
+    lines.push(Line::from(""));
+
+    // Structural analysis (single column).
+    section_heading(&mut lines, "Problem Dimensions");
+    inspect_value_row(&mut lines, "Variables", &analysis.summary.variable_count.to_string());
+    inspect_value_row(&mut lines, "Constraints", &analysis.summary.constraint_count.to_string());
+    inspect_value_row(&mut lines, "Non-zeros", &analysis.summary.total_nonzeros.to_string());
+    inspect_value_row(&mut lines, "Density", &format!("{:.4}%", analysis.summary.density * 100.0));
+    inspect_value_row(
+        &mut lines,
+        "Vars/constraint",
+        &format!("{}\u{2013}{}", analysis.sparsity.min_vars_per_constraint, analysis.sparsity.max_vars_per_constraint),
+    );
+    lines.push(Line::from(""));
+
+    section_heading(&mut lines, "Variable Types");
+    let vt = &analysis.variables.type_distribution;
+    inspect_value_row(&mut lines, "Binary", &vt.binary.to_string());
+    inspect_value_row(&mut lines, "Integer", &vt.integer.to_string());
+    inspect_value_row(&mut lines, "General", &vt.general.to_string());
+    inspect_value_row(&mut lines, "Free", &vt.free.to_string());
+    inspect_value_row(&mut lines, "Lower-bounded", &vt.lower_bounded.to_string());
+    inspect_value_row(&mut lines, "Upper-bounded", &vt.upper_bounded.to_string());
+    inspect_value_row(&mut lines, "Double-bounded", &vt.double_bounded.to_string());
+    inspect_value_row(&mut lines, "Semi-continuous", &vt.semi_continuous.to_string());
+    lines.push(Line::from(""));
+
+    section_heading(&mut lines, "Constraint Types");
+    let ct = &analysis.constraints.type_distribution;
+    inspect_value_row(&mut lines, "Equality (=)", &ct.equality.to_string());
+    inspect_value_row(&mut lines, "<= constraints", &ct.less_than_equal.to_string());
+    inspect_value_row(&mut lines, ">= constraints", &ct.greater_than_equal.to_string());
+    inspect_value_row(&mut lines, "< constraints", &ct.less_than.to_string());
+    inspect_value_row(&mut lines, "> constraints", &ct.greater_than.to_string());
+    inspect_value_row(&mut lines, "SOS1", &ct.sos1.to_string());
+    inspect_value_row(&mut lines, "SOS2", &ct.sos2.to_string());
+    lines.push(Line::from(""));
+
+    section_heading(&mut lines, "Coefficient Scaling");
+    inspect_value_row(
+        &mut lines,
+        "Coeff range",
+        &crate::widgets::numerics::format_range_prec(&analysis.coefficients.constraint_coeff_range, 1),
+    );
+    inspect_value_row(&mut lines, "Coeff ratio", &format_scientific(analysis.coefficients.coefficient_ratio));
+    inspect_value_row(&mut lines, "RHS range", &crate::widgets::numerics::format_range_prec(&analysis.constraints.rhs_range, 1));
+    lines.push(Line::from(""));
+
+    // Issues.
+    section_heading(&mut lines, "Issues");
+    let (errors, warnings, infos) = count_issues(&analysis.issues);
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        issue_count_span(errors, "error", t.error),
+        Span::styled(", ", muted()),
+        issue_count_span(warnings, "warning", t.warning),
+        Span::styled(", ", muted()),
+        issue_count_span(infos, "info", t.info),
+    ]));
+    if analysis.issues.is_empty() {
+        lines.push(Line::from(vec![Span::styled("  No issues detected", muted())]));
+    } else {
+        lines.push(Line::from(""));
+        let label = short_filename(file);
+        for issue in &analysis.issues {
+            lines.push(format_issue_line(&label, issue));
+        }
+    }
+
+    lines
+}
+
+/// Single-column count row for the inspect model-contents table.
+fn inspect_count_row(lines: &mut Vec<Line<'static>>, label: &str, count: usize) {
+    let t = theme();
+    lines.push(Line::from(vec![
+        Span::styled(format!("  {label:<16}"), Style::default().fg(t.text)),
+        Span::styled(format!("{count:>10}"), Style::default().fg(t.text)),
+    ]));
+}
+
+/// Single-column labelled value row for the inspect analysis tables.
+fn inspect_value_row(lines: &mut Vec<Line<'static>>, label: &str, value: &str) {
+    let t = theme();
+    lines.push(Line::from(vec![
+        Span::styled(format!("  {label:<16}"), Style::default().fg(t.text)),
+        Span::styled(format!("{value:>16}"), Style::default().fg(t.text)),
+    ]));
+}
+
 /// Draw the summary content into `area` using pre-built lines (no border — caller provides the border).
 ///
 /// Uses O(visible) windowed rendering instead of cloning all lines into a `Paragraph`.

--- a/tui/src/widgets/summary.rs
+++ b/tui/src/widgets/summary.rs
@@ -14,7 +14,7 @@ use ratatui::text::{Line, Span};
 use crate::diff_model::{DiffCounts, DiffSummary, LpDiffReport};
 use crate::theme::theme;
 use crate::widgets::numerics::format_scientific;
-use crate::widgets::{ARROW, muted, rule_str};
+use crate::widgets::{ARROW, muted, rule_str, severity_colour, short_filename};
 
 /// Build pre-formatted summary lines. Called once at startup since report data never changes.
 pub fn build_summary_lines(
@@ -387,15 +387,6 @@ fn issue_count_span(count: usize, label: &str, colour: Color) -> Span<'static> {
     Span::styled(format!("{count} {label}{plural}"), style)
 }
 
-fn severity_colour(severity: IssueSeverity) -> Color {
-    let t = theme();
-    match severity {
-        IssueSeverity::Error => t.error,
-        IssueSeverity::Warning => t.warning,
-        IssueSeverity::Info => t.info,
-    }
-}
-
 fn format_issue_line(file_label: &str, issue: &lp_parser_rs::analysis::AnalysisIssue) -> Line<'static> {
     let t = theme();
     let colour = severity_colour(issue.severity);
@@ -407,7 +398,3 @@ fn format_issue_line(file_label: &str, issue: &lp_parser_rs::analysis::AnalysisI
     ])
 }
 
-/// Extract the filename from a path string for compact display.
-fn short_filename(path: &str) -> String {
-    std::path::Path::new(path).file_name().map_or_else(|| path.to_string(), |f| f.to_string_lossy().into_owned())
-}


### PR DESCRIPTION
1. Single-file inspect mode (TUI) — lp_diff now accepts one file instead of requiring two. Includes the selection/model plumbing (1b90255), neutral rendering with diff-only actions gated off (49fdbf9), docs (b3e71a2), and a fix to neutralise the search pop-up in
  inspect mode (9b3d57b).

2. MPS writer (core) — new LP-to-MPS conversion wired into convert --format mps (3b72c9a), hardened to reject non-finite single-sided bounds rather than emitting inf (749fa04), with the Free-default conversion caveat documented (14f9cd4).

3. Diff engine extracted into the library — the LP diff logic moved out of the TUI into lp_parser_rs behind a diff feature flag (37d2e5c), so it's usable outside the TUI.

Supporting work: performance improvements to coefficient diff ordering and solve-overlay windowing (aad3ee4), helper deduplication (a05189b), rustfmt/const fn tidy-ups (83a10d2), and the fix from this session — each solve now gets its own solver-log temp file so "Solve both" no longer races and errors (7f137ae).