### PR TITLE
refactor: remove over-engineering flagged by repo audit

### DIFF
--- a/python/parse_lp/__init__.py
+++ b/python/parse_lp/__init__.py
@@ -1,63 +1,8 @@
 """parse_lp - A fast LP file format parser, writer, and modifier for Python, powered by Rust.
 
-This package provides a high-performance parser for Linear Programming (LP) files,
-leveraging Rust for speed and Python for ease of use. It supports parsing, modifying,
-and writing LP files with full round-trip compatibility.
-
-Key Features:
-- Fast parsing of LP files of various formats
-- Programmatic modification of LP problems (objectives, constraints, variables)
-- Write LP problems back to standard LP format
-- Export parsed data to CSV files
-- Access to problem components (variables, constraints, objectives)
-- Type hints for better IDE support
-
-Example Usage:
-    >>> from parse_lp import LpParser
-    >>>
-    >>> # Parse an LP file
-    >>> parser = LpParser("optimization_problem.lp")
-    >>> parser.parse()
-    >>>
-    >>> # Access problem information
-    >>> print(f"Problem name: {parser.name}")
-    >>> print(f"Variables: {len(parser.variables)}")
-    >>> print(f"Constraints: {len(parser.constraints)}")
-    >>>
-    >>> # Modify the problem
-    >>> parser.update_objective_coefficient("profit", "x1", 5.0)
-    >>> parser.rename_variable("x2", "production")
-    >>> parser.update_constraint_rhs("capacity", 100.0)
-    >>> parser.update_variable_type("x1", "integer")
-    >>>
-    >>> # Write back to LP format
-    >>> modified_lp = parser.to_lp_string()
-    >>> parser.save_to_file("modified_problem.lp")
-    >>>
-    >>> # Export to CSV files
-    >>> parser.to_csv("output/")
-
-Modification Methods:
-    Objective modifications:
-    - update_objective_coefficient(obj_name, var_name, coefficient)
-    - rename_objective(old_name, new_name)
-    - remove_objective(obj_name)
-
-    Constraint modifications:
-    - update_constraint_coefficient(const_name, var_name, coefficient)
-    - update_constraint_rhs(const_name, new_rhs)
-    - rename_constraint(old_name, new_name)
-    - remove_constraint(const_name)
-
-    Variable modifications:
-    - rename_variable(old_name, new_name)
-    - update_variable_type(var_name, var_type)  # binary, integer, general, free, semicontinuous
-    - remove_variable(var_name)
-
-    Problem modifications:
-    - set_problem_name(name)
-    - set_sense(sense)  # maximize, minimize
-
+Parse, inspect, modify, and write Linear Programming (LP) files with full
+round-trip compatibility. The public API is the ``LpParser`` class; see the
+README and ``parse_lp.pyi`` stubs for the full method reference.
 """
 
 from importlib.metadata import version as _version

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -46,7 +46,6 @@ impl LpParser {
         self.lp_file.clone()
     }
 
-    #[pyo3(text_signature = "($self)")]
     fn parse(&mut self, py: Python) -> PyResult<()> {
         let path = PathBuf::from(&self.lp_file);
         // Release the GIL while reading and parsing so other Python threads
@@ -60,7 +59,6 @@ impl LpParser {
     }
 
     #[allow(clippy::wrong_self_convention)]
-    #[pyo3(text_signature = "($self, base_directory)")]
     fn to_csv(&mut self, py: Python, base_directory: &str) -> PyResult<()> {
         if !Path::new(&base_directory).is_dir() {
             return Err(PyNotADirectoryError::new_err(format!("Path {base_directory} is not a directory.")));
@@ -170,7 +168,6 @@ impl LpParser {
     }
 
     /// Save the current problem to an LP file
-    #[pyo3(text_signature = "($self, filepath)")]
     fn save_to_file(&self, filepath: String) -> PyResult<()> {
         let problem = self.get_problem()?;
         let lp_content = write_lp_string_with_options(problem, &LpWriterOptions::default());
@@ -178,7 +175,6 @@ impl LpParser {
     }
 
     /// Update coefficient in an objective
-    #[pyo3(text_signature = "($self, objective_name, variable_name, coefficient)")]
     fn update_objective_coefficient(&mut self, objective_name: String, variable_name: String, coefficient: f64) -> PyResult<()> {
         let problem = self.get_problem_mut()?;
         problem
@@ -188,7 +184,6 @@ impl LpParser {
     }
 
     /// Rename an objective
-    #[pyo3(text_signature = "($self, old_name, new_name)")]
     fn rename_objective(&mut self, old_name: String, new_name: String) -> PyResult<()> {
         let problem = self.get_problem_mut()?;
         problem
@@ -199,7 +194,6 @@ impl LpParser {
     }
 
     /// Remove an objective
-    #[pyo3(text_signature = "($self, objective_name)")]
     fn remove_objective(&mut self, objective_name: String) -> PyResult<()> {
         let problem = self.get_problem_mut()?;
         problem
@@ -210,7 +204,6 @@ impl LpParser {
     }
 
     /// Update coefficient in a constraint
-    #[pyo3(text_signature = "($self, constraint_name, variable_name, coefficient)")]
     fn update_constraint_coefficient(&mut self, constraint_name: String, variable_name: String, coefficient: f64) -> PyResult<()> {
         let problem = self.get_problem_mut()?;
         problem
@@ -221,7 +214,6 @@ impl LpParser {
     }
 
     /// Update the right-hand side value of a constraint
-    #[pyo3(text_signature = "($self, constraint_name, new_rhs)")]
     fn update_constraint_rhs(&mut self, constraint_name: String, new_rhs: f64) -> PyResult<()> {
         let problem = self.get_problem_mut()?;
         problem
@@ -232,7 +224,6 @@ impl LpParser {
     }
 
     /// Rename a constraint
-    #[pyo3(text_signature = "($self, old_name, new_name)")]
     fn rename_constraint(&mut self, old_name: String, new_name: String) -> PyResult<()> {
         let problem = self.get_problem_mut()?;
         problem
@@ -243,7 +234,6 @@ impl LpParser {
     }
 
     /// Remove a constraint
-    #[pyo3(text_signature = "($self, constraint_name)")]
     fn remove_constraint(&mut self, constraint_name: String) -> PyResult<()> {
         let problem = self.get_problem_mut()?;
         problem
@@ -254,7 +244,6 @@ impl LpParser {
     }
 
     /// Rename a variable across all objectives and constraints
-    #[pyo3(text_signature = "($self, old_name, new_name)")]
     fn rename_variable(&mut self, old_name: String, new_name: String) -> PyResult<()> {
         let problem = self.get_problem_mut()?;
         problem
@@ -265,7 +254,6 @@ impl LpParser {
     }
 
     /// Update variable type (e.g., Binary, Integer, etc.)
-    #[pyo3(text_signature = "($self, variable_name, var_type)")]
     fn update_variable_type(&mut self, variable_name: String, var_type: String) -> PyResult<()> {
         let problem = self.get_problem_mut()?;
 
@@ -275,7 +263,7 @@ impl LpParser {
             "integer" => VariableType::Integer,
             "general" => VariableType::General,
             "free" => VariableType::Free,
-            "semicontinuous" | "semi_continuous" => VariableType::SemiContinuous,
+            "semicontinuous" => VariableType::SemiContinuous,
             _ => {
                 return Err(LpInvalidValueError::new_err(format!(
                     "Unknown variable type: {var_type}. Supported types: binary, integer, general, free, semicontinuous",
@@ -291,7 +279,6 @@ impl LpParser {
     }
 
     /// Remove a variable from all objectives and constraints
-    #[pyo3(text_signature = "($self, variable_name)")]
     fn remove_variable(&mut self, variable_name: String) -> PyResult<()> {
         let problem = self.get_problem_mut()?;
         problem
@@ -302,7 +289,6 @@ impl LpParser {
     }
 
     /// Set problem name
-    #[pyo3(text_signature = "($self, name)")]
     fn set_problem_name(&mut self, name: String) -> PyResult<()> {
         let problem = self.get_problem_mut()?;
         problem.name = Some(name);
@@ -311,13 +297,12 @@ impl LpParser {
     }
 
     /// Set problem sense (maximize or minimize)
-    #[pyo3(text_signature = "($self, sense)")]
     fn set_sense(&mut self, sense: String) -> PyResult<()> {
         let problem = self.get_problem_mut()?;
 
         problem.sense = match sense.to_lowercase().as_str() {
-            "maximize" | "max" => Sense::Maximize,
-            "minimize" | "min" => Sense::Minimize,
+            "maximize" => Sense::Maximize,
+            "minimize" => Sense::Minimize,
             _ => return Err(LpInvalidValueError::new_err(format!("Invalid sense: {sense}. Use 'maximize' or 'minimize'"))),
         };
 
@@ -348,7 +333,7 @@ impl LpParser {
             coefficient_ratio_threshold: ratio_threshold,
         };
         let analysis = problem.analyze_with_config(&config);
-        self.analysis_to_dict(py, &analysis)
+        analysis_to_dict(py, &analysis)
     }
 
     fn __repr__(&self) -> String {
@@ -369,19 +354,18 @@ impl LpParser {
     fn get_problem_mut(&mut self) -> PyResult<&mut LpProblem> {
         self.problem.as_mut().ok_or_else(|| LpNotParsedError::new_err("Must call parse() first"))
     }
+}
 
-    #[allow(clippy::unused_self)]
-    fn analysis_to_dict(&self, py: Python, analysis: &lp_parser_rs::analysis::ProblemAnalysis) -> PyResult<Py<PyAny>> {
-        // The struct field names match the public dict schema, so serialise the
-        // whole analysis in one step.
-        let dict =
-            pythonize::pythonize(py, analysis).map_err(|err| PyRuntimeError::new_err(format!("Unable to serialise analysis: {err}")))?;
-        // serde serialises the issue severity/category enums by their variant
-        // names; the Python API instead exposes the human-readable Display form,
-        // so overwrite the issues list to preserve that contract.
-        dict.cast::<PyDict>()?.set_item("issues", issues_to_list(py, &analysis.issues)?)?;
-        Ok(dict.into())
-    }
+/// Serialise a [`ProblemAnalysis`](lp_parser_rs::analysis::ProblemAnalysis) to a Python dict.
+fn analysis_to_dict(py: Python, analysis: &lp_parser_rs::analysis::ProblemAnalysis) -> PyResult<Py<PyAny>> {
+    // The struct field names match the public dict schema, so serialise the
+    // whole analysis in one step.
+    let dict = pythonize::pythonize(py, analysis).map_err(|err| PyRuntimeError::new_err(format!("Unable to serialise analysis: {err}")))?;
+    // serde serialises the issue severity/category enums by their variant
+    // names; the Python API instead exposes the human-readable Display form,
+    // so overwrite the issues list to preserve that contract.
+    dict.cast::<PyDict>()?.set_item("issues", issues_to_list(py, &analysis.issues)?)?;
+    Ok(dict.into())
 }
 
 /// Build a list of `{name, value}` dicts from coefficients, resolving interned names.

--- a/rust/src/assemble.rs
+++ b/rust/src/assemble.rs
@@ -3,7 +3,7 @@
 //! The LALRPOP grammar cannot decide with one token of lookahead whether
 //! `... + 10 obj2: y` ends an objective with the constant `10` or scales a
 //! variable named `obj2`, so the grammar collects each section body as a flat
-//! list of [`Elem`]s and the functions here assemble entries with unbounded
+//! list of [`Elem`](crate::assemble::Elem)s and the functions here assemble entries with unbounded
 //! lookahead. This is also what enables spec features the old grammar
 //! rejected: constant terms (`obj: x + 10`, `c1: x + 2 <= 10`), empty
 //! objectives, flipped constraints (`10 >= x`), and ranged constraints

--- a/rust/src/compat/lp_solvers.rs
+++ b/rust/src/compat/lp_solvers.rs
@@ -171,6 +171,11 @@ pub struct ExpressionAdapter<'a> {
     interner: &'a NameInterner,
 }
 
+/// Decimal precision for coefficients emitted to `lp-solvers`. High enough to
+/// preserve solver-relevant fidelity; `write_formatted_coefficient` trims
+/// trailing zeros so whole numbers stay compact.
+const COEFFICIENT_PRECISION: usize = 15;
+
 impl WriteToLpFileFormat for ExpressionAdapter<'_> {
     fn to_lp_file_format(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Filter out zero and non-finite coefficients
@@ -181,36 +186,19 @@ impl WriteToLpFileFormat for ExpressionAdapter<'_> {
             return write!(f, "0");
         }
 
+        // Reuse the LP writer's coefficient formatter so both front-ends emit
+        // identical output. It writes to a `String`, so buffer then flush.
+        let mut out = String::new();
         for (i, coeff) in non_zero.iter().enumerate() {
-            let value = coeff.value;
-            let name = self.interner.resolve(coeff.name);
-
-            if i == 0 {
-                // First term
-                if value < 0.0 {
-                    if (value.abs() - 1.0).abs() < NUMERIC_EPSILON {
-                        write!(f, "- {name}")?;
-                    } else {
-                        write!(f, "- {} {name}", value.abs())?;
-                    }
-                } else if (value - 1.0).abs() < NUMERIC_EPSILON {
-                    write!(f, "{name}")?;
-                } else {
-                    write!(f, "{value} {name}")?;
-                }
-            } else {
-                // Subsequent terms
-                let sign = if value < 0.0 { "-" } else { "+" };
-                let abs_val = value.abs();
-
-                if (abs_val - 1.0).abs() < NUMERIC_EPSILON {
-                    write!(f, " {sign} {name}")?;
-                } else {
-                    write!(f, " {sign} {abs_val} {name}")?;
-                }
-            }
+            crate::writer::write_formatted_coefficient(
+                &mut out,
+                self.interner.resolve(coeff.name),
+                coeff.value,
+                i == 0,
+                COEFFICIENT_PRECISION,
+            )?;
         }
-        Ok(())
+        f.write_str(&out)
     }
 }
 
@@ -337,12 +325,6 @@ impl<'a> LpSolversCompat<'a> {
     pub fn warnings(&self) -> &[LpSolversCompatWarning] {
         &self.warnings
     }
-
-    /// Returns `true` if there are no warnings.
-    #[must_use]
-    pub fn is_fully_compatible(&self) -> bool {
-        self.warnings.is_empty()
-    }
 }
 
 impl<'a> lp_solvers::lp_format::LpProblem<'a> for LpSolversCompat<'a> {
@@ -445,7 +427,7 @@ mod tests {
         let sos1_id = p.intern("sos1");
         p.constraints.insert(sos1_id, Constraint::SOS { name: sos1_id, sos_type: SOSType::S1, weights: vec![], byte_offset: None });
         let c = LpSolversCompat::try_new(&p).unwrap();
-        assert!(!c.is_fully_compatible());
+        assert!(!c.warnings().is_empty());
         assert!(matches!(&c.warnings()[0], LpSolversCompatWarning::SosConstraintIgnored { .. }));
 
         // Semi-continuous

--- a/rust/src/diff.rs
+++ b/rust/src/diff.rs
@@ -13,7 +13,7 @@
 //!   name normaliser so callers can rewrite variable/constraint/objective
 //!   names (e.g. the CLI's regex `--rename` rules) *without* forcing a
 //!   `regex` dependency onto this crate.
-//! - [`compare`] (or the convenience [`LpProblem::diff`] method) walks both
+//! - [`compare`](crate::diff::compare) (or the convenience [`LpProblem::diff`] method) walks both
 //!   problems and returns an [`LpDiff`] describing every added, removed, or
 //!   modified variable, constraint, and objective.
 //!
@@ -65,14 +65,6 @@ impl Default for DiffTol {
 }
 
 impl DiffTol {
-    /// Construct a tolerance from an absolute and a relative component.
-    #[must_use]
-    pub fn new(abs: f64, rel: f64) -> Self {
-        debug_assert!(abs.is_finite() && abs >= 0.0, "abs tolerance must be finite and non-negative");
-        debug_assert!(rel.is_finite() && rel >= 0.0, "rel tolerance must be finite and non-negative");
-        Self { abs, rel }
-    }
-
     /// Return true if `a` and `b` differ beyond both tolerances.
     #[must_use]
     pub fn differ(self, a: f64, b: f64) -> bool {
@@ -337,7 +329,7 @@ mod tests {
 
     #[test]
     fn tol_equal_within_absolute() {
-        let tol = DiffTol::new(0.5, 0.0);
+        let tol = DiffTol { abs: 0.5, rel: 0.0 };
         // Difference of 0.4 is within abs=0.5.
         assert!(!tol.differ(1.0, 1.4));
         // Difference of 0.6 exceeds abs=0.5.
@@ -347,7 +339,7 @@ mod tests {
     #[test]
     fn tol_relative_scales_with_magnitude() {
         // 1% relative tolerance.
-        let tol = DiffTol::new(0.0, 0.01);
+        let tol = DiffTol { abs: 0.0, rel: 0.01 };
         // 0.5% change is within tolerance.
         assert!(!tol.differ(1000.0, 1005.0));
         // 2% change exceeds tolerance.
@@ -357,7 +349,7 @@ mod tests {
     #[test]
     fn tol_requires_both_tolerances_exceeded() {
         // Differs only if BEYOND both abs AND rel.
-        let tol = DiffTol::new(10.0, 0.5);
+        let tol = DiffTol { abs: 10.0, rel: 0.5 };
         // diff 8: below abs(10) -> not different even though 8 > 0.5*10.
         assert!(!tol.differ(10.0, 18.0));
         // diff 12: above abs(10) but 12 < 0.5*24 -> not different.
@@ -376,7 +368,7 @@ mod tests {
 
     #[test]
     fn tol_zero_baseline() {
-        let tol = DiffTol::new(0.0, 0.5);
+        let tol = DiffTol { abs: 0.0, rel: 0.5 };
         // Relative scale is max(|0|, |1|) = 1; diff 1 > 0.5 -> different.
         assert!(tol.differ(0.0, 1.0));
         // Both zero -> no difference.
@@ -454,7 +446,7 @@ mod tests {
         let p1 = parse("Minimize\n obj: x\nSubject To\n c1: x >= 100\nEnd");
         let p2 = parse("Minimize\n obj: x\nSubject To\n c1: x >= 100.4\nEnd");
         // abs tolerance 0.5 suppresses the 0.4 rhs change.
-        let diff = p1.diff(&p2, &opts(DiffTol::new(0.5, 0.0)));
+        let diff = p1.diff(&p2, &opts(DiffTol { abs: 0.5, rel: 0.0 }));
         assert!(diff.cons_modified.is_empty());
         // Without tolerance the change is reported.
         let diff = p1.diff(&p2, &opts(DiffTol::default()));

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -1,5 +1,3 @@
-use std::io;
-
 use thiserror::Error;
 
 use crate::lexer::{LexerError, Token};
@@ -111,20 +109,6 @@ impl<'input> From<lalrpop_util::ParseError<usize, Token<'input>, LexerError>> fo
     }
 }
 
-/// Convert from standard I/O errors
-impl From<io::Error> for LpParseError {
-    fn from(err: io::Error) -> Self {
-        Self::io_error(err.to_string())
-    }
-}
-
-/// Convert from boxed errors (used by CSV module)
-impl From<Box<dyn std::error::Error + 'static>> for LpParseError {
-    fn from(err: Box<dyn std::error::Error + 'static>) -> Self {
-        Self::io_error(err.to_string())
-    }
-}
-
 /// Result type alias for LP parsing operations
 pub type LpResult<T> = Result<T, LpParseError>;
 
@@ -136,16 +120,5 @@ mod tests {
     fn test_error_creation() {
         let err = LpParseError::invalid_bounds("x", "lower exceeds upper");
         assert_eq!(err.to_string(), "Invalid bounds for variable 'x': lower exceeds upper");
-    }
-
-    #[test]
-    fn test_io_error_conversion() {
-        let io_err = io::Error::new(io::ErrorKind::NotFound, "file not found");
-        let lp_err: LpParseError = io_err.into();
-
-        match lp_err {
-            LpParseError::IoError { message } => assert!(message.contains("file not found")),
-            _ => panic!("Expected IoError"),
-        }
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -65,7 +65,7 @@ pub mod writer;
 // Crate-root re-exports of the primary public API, so downstream users do not
 // need deep module paths for the most common types and entry points.
 #[cfg(feature = "diff")]
-pub use diff::{DiffOptions, DiffTol, LpDiff, Normaliser, compare as compare_diff};
+pub use diff::{DiffOptions, DiffTol, LpDiff, Normaliser};
 pub use error::{LpParseError, LpResult};
 pub use interner::{NameId, NameInterner};
 // LALRPOP generated grammar module

--- a/rust/src/model.rs
+++ b/rust/src/model.rs
@@ -13,10 +13,9 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 use crate::interner::NameId;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Represents comparison operations that can be used to compare values.
 pub enum ComparisonOp {
-    #[default]
     /// Greater than
     GT,
     /// Greater than or equal
@@ -63,15 +62,6 @@ pub enum Sense {
     Minimize,
     /// Maximise the objective function.
     Maximize,
-}
-
-impl Sense {
-    #[inline]
-    #[must_use]
-    /// Determines if the current optimisation sense is minimisation.
-    pub const fn is_minimisation(&self) -> bool {
-        matches!(self, Self::Minimize)
-    }
 }
 
 impl Display for Sense {
@@ -296,8 +286,6 @@ mod tests {
 
     #[test]
     fn test_comparison_op() {
-        assert_eq!(ComparisonOp::default(), ComparisonOp::GT);
-
         let test_cases = [
             (ComparisonOp::GT, b">".as_slice(), ">"),
             (ComparisonOp::GTE, b">=".as_slice(), ">="),
@@ -316,8 +304,6 @@ mod tests {
     #[test]
     fn test_sense() {
         assert_eq!(Sense::default(), Sense::Minimize);
-        assert!(Sense::Minimize.is_minimisation());
-        assert!(!Sense::Maximize.is_minimisation());
         assert_eq!(format!("{}", Sense::Minimize), "Minimize");
         assert_eq!(format!("{}", Sense::Maximize), "Maximize");
         assert_ne!(Sense::Minimize, Sense::Maximize);

--- a/rust/src/mps/writer.rs
+++ b/rust/src/mps/writer.rs
@@ -62,8 +62,7 @@
 //!   is an LP-format-only distinction that has no MPS analogue.
 //! - [`SemiContinuous`](crate::model::VariableType::SemiContinuous) carries no
 //!   explicit upper bound in this model, but the MPS `SC` bound type requires
-//!   one. A sentinel value
-//!   ([`SEMI_CONTINUOUS_SENTINEL_UPPER`](crate::mps::writer::SEMI_CONTINUOUS_SENTINEL_UPPER))
+//!   one. A sentinel value (`SEMI_CONTINUOUS_SENTINEL_UPPER`, `1e30`)
 //!   is written instead, and the reader resolves any `SC` bound back to
 //!   `SemiContinuous`, so the type round trips. The flip side: an `SC` bound
 //!   in an *external* MPS file with a meaningful finite upper bound has that
@@ -80,10 +79,10 @@
 //!   keeps it correct at the cost of re-parsing as `DoubleBound(0, ub)`
 //!   rather than `UpperBound(ub)` (the same feasible region, a different
 //!   variant).
-//! - **Free-default conversion caveat**: [`LpProblem`] defaults an
+//! - **Free-default conversion caveat**: [`LpProblem`](crate::problem::LpProblem) defaults an
 //!   undeclared variable that only appears in constraints (never in a
 //!   `Bounds`/`Free`/etc. section, and never given an explicit bound) to
-//!   [`VariableType::Free`], which this writer faithfully emits as an `FR`
+//!   [`VariableType::Free`](crate::model::VariableType::Free), which this writer faithfully emits as an `FR`
 //!   bound. LP format's own default for such a variable is `[0, +inf)`, not
 //!   free -- so converting an LP file straight through this writer without
 //!   ever having declared the variable's bounds widens its feasible region
@@ -112,7 +111,7 @@ pub const EMPTY_OBJECTIVE_ROW_NAME: &str = "OBJ";
 /// Sentinel upper bound written for [`VariableType::SemiContinuous`] variables,
 /// which carry no explicit upper bound in this model. `1e30` is the
 /// conventional "infinity" sentinel used by CPLEX/Gurobi-style MPS files.
-pub const SEMI_CONTINUOUS_SENTINEL_UPPER: f64 = 1e30;
+pub(crate) const SEMI_CONTINUOUS_SENTINEL_UPPER: f64 = 1e30;
 
 /// Fixed vector label written in the RHS section (the first field of each
 /// RHS data line). The MPS reader accepts any label; only the first

--- a/rust/src/problem.rs
+++ b/rust/src/problem.rs
@@ -1166,12 +1166,12 @@ End";
     fn test_problem_lifecycle() {
         let problem = LpProblem::new();
         assert_eq!(problem.name(), None);
-        assert!(problem.sense.is_minimisation());
+        assert_eq!(problem.sense, Sense::Minimize);
         assert_eq!((problem.objective_count(), problem.constraint_count(), problem.variable_count()), (0, 0, 0));
 
         let problem = LpProblem::new().with_problem_name("test").with_sense(Sense::Maximize);
         assert_eq!(problem.name(), Some("test"));
-        assert!(!problem.sense.is_minimisation());
+        assert_eq!(problem.sense, Sense::Maximize);
 
         let display = format!("{problem}");
         assert!(display.contains("Problem name: test") && display.contains("Sense: Maximize"));

--- a/rust/src/writer.rs
+++ b/rust/src/writer.rs
@@ -366,7 +366,16 @@ fn write_coefficients_line(
 }
 
 /// Write a formatted coefficient directly to the output buffer, avoiding intermediate `String` allocation.
-fn write_formatted_coefficient(output: &mut String, name: &str, value: f64, is_first: bool, precision: usize) -> std::fmt::Result {
+///
+/// `pub(crate)` so the `lp-solvers` compat adapter ([`crate::compat::lp_solvers`])
+/// emits coefficients identically to the LP writer.
+pub(crate) fn write_formatted_coefficient(
+    output: &mut String,
+    name: &str,
+    value: f64,
+    is_first: bool,
+    precision: usize,
+) -> std::fmt::Result {
     debug_assert!(!name.is_empty(), "coefficient name must not be empty");
     debug_assert!(value.is_finite(), "coefficient value must be finite, got: {value}");
     let abs_value = value.abs();

--- a/rust/tests/test_lp_solvers_compat.rs
+++ b/rust/tests/test_lp_solvers_compat.rs
@@ -22,7 +22,7 @@ fn test_diet_file_converts_to_lp_solvers() {
 
     let compat = LpSolversCompat::try_new(&problem).expect("failed to convert to lp-solvers format");
 
-    assert!(compat.is_fully_compatible());
+    assert!(compat.warnings().is_empty());
     assert_eq!(compat.name(), "diet");
     assert!(matches!(LpSolversProblem::sense(&compat), LpObjective::Minimize));
 }
@@ -45,7 +45,7 @@ fn test_sos_file_converts_with_warning() {
 
     let compat = LpSolversCompat::try_new(&problem).expect("failed to convert to lp-solvers format");
 
-    assert!(!compat.is_fully_compatible());
+    assert!(!compat.warnings().is_empty());
     assert!(!compat.warnings().is_empty());
 }
 

--- a/tui/src/solver.rs
+++ b/tui/src/solver.rs
@@ -547,7 +547,7 @@ pub fn solve_problem(problem: &LpProblem) -> Result<SolveResult, String> {
     let model = build_highs_model(problem);
     let build_time = build_start.elapsed();
 
-    // ponytail: pid+sequence-named temp file + explicit cleanup instead of the
+    // pid+sequence-named temp file + explicit cleanup instead of the
     // tempfile crate. The sequence number keeps concurrent solves in one process
     // ("Solve both" runs two solver threads) from clobbering each other's log.
     let log_seq = SOLVE_LOG_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -70,13 +70,7 @@ impl SolveTab {
     pub const ALL: [Self; 5] = [Self::Summary, Self::Variables, Self::Constraints, Self::Log, Self::Duals];
 
     pub const fn index(self) -> usize {
-        match self {
-            Self::Summary => 0,
-            Self::Variables => 1,
-            Self::Constraints => 2,
-            Self::Log => 3,
-            Self::Duals => 4,
-        }
+        self as usize
     }
 
     pub const fn label(self) -> &'static str {
@@ -213,17 +207,10 @@ impl Section {
     pub const ALL: [Self; 5] = [Self::Summary, Self::Variables, Self::Constraints, Self::Objectives, Self::Numerics];
 
     pub const fn index(self) -> usize {
-        match self {
-            Self::Summary => 0,
-            Self::Variables => 1,
-            Self::Constraints => 2,
-            Self::Objectives => 3,
-            Self::Numerics => 4,
-        }
+        self as usize
     }
 
     pub fn from_index(i: usize) -> Self {
-        debug_assert!(i < Self::ALL.len(), "Section::from_index called with out-of-range index {i}");
         match i {
             0 => Self::Summary,
             1 => Self::Variables,


### PR DESCRIPTION
Whole-repo audit for dead code, duplication, and unused flexibility.

Rust core:
- ExpressionAdapter reuses writer::write_formatted_coefficient instead of duplicating the coefficient formatting
- delete unused From<Box<dyn Error>> / From<io::Error> impls, is_minimisation, DiffTol::new, compare_diff alias; inline is_fully_compatible
- drop ComparisonOp's unused Default derive
- narrow SEMI_CONTINUOUS_SENTINEL_UPPER to pub(crate)

TUI:
- SolveTab::index / Section::index become `self as usize`
- drop redundant debug_assert in Section::from_index

Python:
- shrink __init__.py docstring (duplicated README/.pyi)
- remove 15 text_signature attrs (pyo3 auto-derives them)
- analysis_to_dict becomes a free function
- drop untested semi_continuous / max / min aliases

Net -154 lines. cargo build/clippy/test clean; 293 rust, 114 tui, 79 python tests pass.